### PR TITLE
Gborough/restore sexp

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+## 0.3.0 (2025-03-27)
+
+* Documentation improvement
+
+Breaking changes:
+
+* Restored sexp support and other printing output field changes
+* Labelled function changes on Discrete, Exchange and Quotient types
+* Removed deriving show on all types
+* Removed printing support for Zv and Qv
+
 ## 0.2.0 (2024-04-26)
 
 * Removed transitive dependecies

--- a/dune-project
+++ b/dune-project
@@ -20,4 +20,19 @@
  (authors "Geoffrey Borough")
  (synopsis "A type safe money manipulation library")
  (description "A type safe money manipulation library")
- (depends (ocaml (>= 4.14.0)) base dune (zarith (>= 1.5.0)) stdint (angstrom (>= 0.16.0)) re2 yojson ppx_deriving ppx_deriving_yojson ppx_jane (ppx_expect :with-test)))
+ (depends
+  (ocaml
+   (>= 4.14.0))
+  base
+  dune
+  (zarith
+   (>= 1.5.0))
+  stdint
+  (angstrom
+   (>= 0.16.0))
+  re2
+  yojson
+  ppx_deriving
+  ppx_deriving_yojson
+  ppx_jane
+  (ppx_expect :with-test)))

--- a/lib/discrete.ml
+++ b/lib/discrete.ml
@@ -1,20 +1,19 @@
+open Sexplib.Std
+
 module Make (Qv : Qv_intf.S) (Zv : Zv_intf.S) = struct
   exception ScaleTypeMismatch of string
 
   module Scale = struct
     exception ValidScaleError of string
 
-    type t =
-      { symbol: string [@compare.ignore]
-      ; unit: string [@compare.ignore]
-      ; value: Qv.t }
-    [@@deriving compare]
+    type t = {symbol_: string; sub_unit_: string; value_: Qv.t}
 
     type showable =
-      { symbol_: string [@key "symbol"]
-      ; unit_: string [@key "unit"]
-      ; value_: string [@key "value"] }
-    [@@deriving show, yojson]
+      { kind: string [@key "kind"]
+      ; symbol: string [@key "symbol"]
+      ; sub_unit: string [@key "sub_unit"]
+      ; value: string [@key "value"] }
+    [@@deriving yojson, sexp]
 
     let check_scale scale =
       if
@@ -23,59 +22,85 @@ module Make (Qv : Qv_intf.S) (Zv : Zv_intf.S) = struct
       then true
       else false
 
-    let make_scale symbol unit value =
-      if check_scale value then {symbol; unit; value}
+    let make_scale ~sym ~sub_unit value_ =
+      if check_scale value_ then {symbol_= sym; sub_unit_= sub_unit; value_}
       else raise (ValidScaleError "Valid scale must be greater than 0")
 
     let to_json x =
       Yojson.Safe.to_string
       @@ showable_to_yojson
-           {symbol_= x.symbol; unit_= x.unit; value_= Qv.S.to_str x.value}
+           { kind= "scale_value"
+           ; symbol= x.symbol_
+           ; sub_unit= x.sub_unit_
+           ; value= Qv.S.to_str x.value_ }
+
+    let showable_of_t t =
+      { kind= "scale_value"
+      ; symbol= t.symbol_
+      ; sub_unit= t.sub_unit_
+      ; value= Qv.S.to_str t.value_ }
+
+    let to_sexp t = sexp_of_showable @@ showable_of_t t
   end
 
-  type t = {scale: Scale.t; value: Zv.t} [@@deriving compare]
+  type t = {scale_: Scale.t; value_: Zv.t}
 
   type showable =
-    { scale_: string [@key "discrete_scale"]
-    ; value_: string [@key "discrete_value"] }
-  [@@deriving show, yojson]
+    { kind: string [@key "kind"]
+    ; symbol: string [@key "symbol"]
+    ; sub_unit: string [@key "sub_unit"]
+    ; s_value: string [@key "scale_value"]
+    ; value: string [@key "discrete_value"] }
+  [@@deriving yojson, sexp]
 
-  let check_scale t1 t2 =
-    if Scale.compare t1.scale t2.scale = 0 then true else false
+  let check_scale t1 t2 = if t1.scale_ == t2.scale_ then true else false
 
-  let make_dv (scale, value) = {scale; value}
+  let make_dv (scale_, value_) = {scale_; value_}
 
   let show_scale t =
-    Printf.printf "(%s %s %s)" t.scale.symbol t.scale.unit
-      (Qv.S.to_str t.scale.value)
+    Printf.printf "(%s %s %s)" t.scale_.symbol_ t.scale_.sub_unit_
+      (Qv.S.to_str t.scale_.value_)
 
-  let show_val t = Printf.printf "%s" (Zv.S.to_str t.value)
+  let show_val t = Printf.printf "%s" (Zv.S.to_str t.value_)
 
   let show_t t =
-    Printf.printf "(%s %s %s %s)" t.scale.symbol t.scale.unit
-      (Qv.S.to_str t.scale.value)
-      (Zv.S.to_str t.value)
+    Printf.printf "(%s %s %s %s)" t.scale_.symbol_ t.scale_.sub_unit_
+      (Qv.S.to_str t.scale_.value_)
+      (Zv.S.to_str t.value_)
 
-  let neg t = {t with value= Zv.S.neg t.value}
+  let neg t = {t with value_= Zv.S.neg t.value_}
 
-  let abs t = {t with value= Zv.S.abs t.value}
+  let abs t = {t with value_= Zv.S.abs t.value_}
 
   let ( + ) t1 t2 =
-    if check_scale t1 t2 then {t1 with value= Zv.S.add t1.value t2.value}
+    if check_scale t1 t2 then {t1 with value_= Zv.S.add t1.value_ t2.value_}
     else
       raise
         (ScaleTypeMismatch "cannot operate on two different currency scales")
 
   let ( - ) t1 t2 =
-    if check_scale t1 t2 then {t1 with value= Zv.S.sub t1.value t2.value}
+    if check_scale t1 t2 then {t1 with value_= Zv.S.sub t1.value_ t2.value_}
     else
       raise
         (ScaleTypeMismatch "cannot operate on two different currency scales")
 
-  let ( * ) ~t ~value = {t with value= Zv.S.mul t.value value}
+  let ( * ) t value = {t with value_= Zv.S.mul t.value_ value}
 
-  let to_json x =
+  let to_json t =
     Yojson.Safe.to_string
     @@ showable_to_yojson
-         {scale_= Scale.to_json x.scale; value_= Zv.S.to_json x.value}
+         { kind= "discrete_value"
+         ; symbol= t.scale_.symbol_
+         ; sub_unit= t.scale_.sub_unit_
+         ; s_value= Qv.S.to_str t.scale_.value_
+         ; value= Zv.S.to_str t.value_ }
+
+  let showable_of_t t =
+    { kind= "discrete_value"
+    ; symbol= t.scale_.symbol_
+    ; sub_unit= t.scale_.sub_unit_
+    ; s_value= Qv.S.to_str t.scale_.value_
+    ; value= Zv.S.to_str t.value_ }
+
+  let to_sexp t = sexp_of_showable @@ showable_of_t t
 end

--- a/lib/discrete.ml
+++ b/lib/discrete.ml
@@ -26,13 +26,13 @@ module Make (Qv : Qv_intf.S) (Zv : Zv_intf.S) = struct
       if check_scale value_ then {symbol_= sym; sub_unit_= sub_unit; value_}
       else raise (ValidScaleError "Valid scale must be greater than 0")
 
-    let to_json x =
+    let to_json t =
       Yojson.Safe.to_string
       @@ showable_to_yojson
            { kind= "scale_value"
-           ; symbol= x.symbol_
-           ; sub_unit= x.sub_unit_
-           ; value= Qv.S.to_str x.value_ }
+           ; symbol= t.symbol_
+           ; sub_unit= t.sub_unit_
+           ; value= Qv.S.to_str t.value_ }
 
     let showable_of_t t =
       { kind= "scale_value"

--- a/lib/discrete.mli
+++ b/lib/discrete.mli
@@ -10,71 +10,62 @@ module Make (Qv : Qv_intf.S) (Zv : Zv_intf.S) : sig
 
     (** {1 Types} *)
     type t =
-      { symbol: string  (** Currency Symbol *)
-      ; unit: string  (** Currency Unit Name *)
-      ; value: Qv.t  (** Scale Value in Rational *) }
-    [@@deriving compare]
-    (** Scale Representation
+      { symbol_: string  (** currency symbol *)
+      ; sub_unit_: string  (** currency unit name *)
+      ; value_: Qv.t  (** scale value in rational *) }
+    (** Type of scale
 
         Almost every currency has a unit value and sub unit values
         e.g. Pound is unit value for GBP with a scale of 1 to 1
-        Penny is sub unit value for GBP with scale of 100 to 1. *)
-
-    (** showable for t *)
-    type showable =
-      { symbol_: string [@key "symbol"]
-      ; unit_: string [@key "unit"]
-      ; value_: string [@key "value"] }
-    [@@deriving show, yojson]
+        Penny is sub unit value for GBP with scale of 100 to 1 *)
 
     (** {1 Construction} *)
-    val make_scale : string -> string -> Qv.t -> t
-    (** Construct exchange rate, e.g. make_scale "GBP" "penny" Utils.make_q("100/1") *)
-
-    val check_scale : Qv.t -> bool
-    (** Required scale to be position *)
+    val make_scale : sym:string -> sub_unit:string -> Qv.t -> t
+    (** [make_scale symbol subunit qv] makes exchange rate, e.g. make_scale "GBP" "penny" make_q("100/1") *)
 
     val to_json : t -> string
-    (** Convert t to json *)
+    (** [to_json t] converts t to json *)
+
+    val to_sexp : t -> Base.Sexp.t
+    (** [to_sexp t] converts t to sexp *)
   end
 
   (** {1 Types} *)
   type t =
-    {scale: Scale.t  (** Scale Setting *); value: Zv.t  (** Integer Value *)}
-
-  (** showable for t *)
-  type showable =
-    {scale_: string [@key "scale"]; value_: string [@key "value"]}
-  [@@deriving show, yojson]
+    { scale_: Scale.t  (** Scale Setting *)
+    ; value_: Zv.t  (** Integer Value *) }
 
   (** {1 Construction} *)
   val make_dv : Scale.t * Zv.t -> t
-  (** Construct discrete value*)
+  (** [make_dv scale zv] constructs t with scale and zv*)
 
   val show_scale : t -> unit
-  (** Print the scale setting *)
+  (** [show_scale t] prints t's scale setting *)
 
   val show_val : t -> unit
-  (** Print the integer value *)
+  (** [show_val t] prints t's discrete integer value *)
 
   val show_t : t -> unit
-  (** Print the discrete value *)
+  (** [show_t t] prints t *)
 
   val neg : t -> t
-  (** Negate a discrete integer value *)
+  (** [neg t] negates t's discrete integer value *)
 
   val abs : t -> t
-  (** Return an absolute discrete integer value *)
+  (** [abs t] returns t's absolute discrete integer value *)
 
   val ( + ) : t -> t -> t
-  (** Add two discrete integer values *)
+  (** [t + qv] adds two t *)
 
   val ( - ) : t -> t -> t
-  (** Substract two discrete integer values *)
+  (** [t - qv] substract two t *)
 
-  val ( * ) : t:t -> value:Zv.t -> t
-  (** Multiply two discrete integer values *)
+  val ( * ) : t -> Zv.t -> t
+  (** [t * qv] multiplies t's value part with a discrete integer values *)
 
   val to_json : t -> string
-  (** Convert t to json *)
+  (** [to_json t] converts t to json string *)
+
+  val to_sexp : t -> Base.Sexp.t
+  (** [to_sexp t] converts t to sexp*)
 end

--- a/lib/dune
+++ b/lib/dune
@@ -10,4 +10,4 @@
   yojson
   ppx_deriving_yojson.runtime)
  (preprocess
-  (pps ppx_jane ppx_deriving_yojson ppx_deriving.show)))
+  (pps ppx_jane ppx_deriving_yojson ppx_deriving.show ppx_sexp_conv)))

--- a/lib/exchange.mli
+++ b/lib/exchange.mli
@@ -5,31 +5,27 @@ module Make (Qv : Qv_intf.S) : sig
 
   (** {1 Types} *)
   type t =
-    { src: string  (** Source. *)
-    ; dst: string  (** Destination. *)
-    ; value: Qv.t  (** Exhange Rate. *) }
-  [@@deriving compare]
-
-  (** showable for t *)
-  type showable =
-    { src_: string [@key "src"]
-    ; dst_: string [@key "dst"]
-    ; value_: string [@key "value"] }
-  [@@deriving show, yojson]
+    { src_: string  (** source *)
+    ; dst_: string  (** destination *)
+    ; value_: Qv.t  (** exhange rate *) }
+  (** Type of exhange rate *)
 
   (** {1 Construction} *)
   val make_xchg : src:string -> dst:string -> Qv.t -> t
-  (** Construct exchange rate, e.g. make_xchg "GBP" "AUD" Utils.make_q(19400/1000) *)
+  (** [make_xchg src dst qv] makes an exchange rate, taking a src: "GBP", a dst: "AUD", and a qv: make_q(19400/1000) *)
 
   val show_xchg : t -> unit
-  (** Print the exchange rate*)
+  (** [show_xchg t] prints t *)
 
   val ( **> ) : t -> t -> t
-  (** Exchange rate composition *)
+  (** [ t1 **> t2 ] composes two different exchange rates, dst of t1 must equal to src of t2 *)
 
   val xchg_recip : t -> t
-  (** Apply reciprocal to exchange rate. xchg_recip (xchg_recip xchg) = id *)
+  (** [xchg_recip t] applies reciprocal to exchange rate, xchg_recip (xchg_recip xchg) = id *)
 
   val to_json : t -> string
-  (** Convert t to json*)
+  (** [to_json t] converts t to json string *)
+
+  val to_sexp : t -> Base.Sexp.t
+  (** [to_sexp t] converts t to sexp *)
 end

--- a/lib/ops.ml
+++ b/lib/ops.ml
@@ -82,8 +82,8 @@ let mark_thousands ~v ~sep =
     Sequence.fold ~init:"" ~f:(Fn.flip ( ^ ))
       (Sequence.unfold ~init:v ~f:(fun i -> aux ~sep ~i))
 
-let q_to_decimal ~printing_conf ~qv =
-  let qv = Qv.S.to_float qv in
+let q_to_decimal ~printing_conf ~q =
+  let qv = Qv.S.to_float q in
   let sep1 = Separator.fst printing_conf.separator in
   let sep2 =
     Option.value (Separator.snd printing_conf.separator) ~default:""
@@ -155,23 +155,23 @@ let q_to_decimal ~printing_conf ~qv =
 
 (** Unsafely convert a float/decimal value of string rep to integer value.
     It is unsafe in a sense that the origin of float/decimal is deemed to
-    be unverified by default and might be as a result of lossy operations. *)
+    be unverified by default and might be as a result of lossy operations *)
 let unsafe_integer_to_z integer = Z.to_string @@ Z.of_int integer
 
 let seal_quotient ~printing_conf ~(qv : Quotient.t) =
-  q_to_decimal ~printing_conf ~qv:qv.value
+  q_to_decimal ~printing_conf ~q:qv.value_
 
 let seal_discrete ~printing_conf ~(dv : Discrete.t) =
   let z_to_q =
-    Qv.S.div (Qv.S.make (Zv.S.to_str dv.value ^ "/1")) dv.scale.value
+    Qv.S.div (Qv.S.make (Zv.S.to_str dv.value_ ^ "/1")) dv.scale_.value_
   in
-  q_to_decimal ~printing_conf ~qv:z_to_q
+  q_to_decimal ~printing_conf ~q:z_to_q
 
 let seal_exchange ~printing_conf ~(xchg : Exchange.t) =
-  q_to_decimal ~printing_conf ~qv:xchg.value
+  q_to_decimal ~printing_conf ~q:xchg.value_
 
 let seal_scale ~printing_conf ~(scale : Discrete.Scale.t) =
-  q_to_decimal ~printing_conf ~qv:scale.value
+  q_to_decimal ~printing_conf ~q:scale.value_
 
 let unsafe_decimal_to_q ~decimal ~sep =
   let sep1 = Separator.fst sep in
@@ -222,7 +222,7 @@ let unsafe_float_to_exchange ~src ~dst ~decimal ~sep =
   | Ok qv -> Exchange.make_xchg ~src ~dst (Qv.S.make qv)
   | Error msg -> failwith msg
 
-let unsafe_float_to_scale ~symbol ~unit ~decimal ~sep =
+let unsafe_float_to_scale ~sym ~sub_unit ~decimal ~sep =
   match unsafe_decimal_to_q ~decimal ~sep with
-  | Ok qv -> Discrete.Scale.make_scale symbol unit (Qv.S.make qv)
+  | Ok qv -> Discrete.Scale.make_scale ~sym ~sub_unit (Qv.S.make qv)
   | Error msg -> failwith msg

--- a/lib/ops.mli
+++ b/lib/ops.mli
@@ -1,7 +1,7 @@
 open Types
 open Stdint
 
-(** Float round strategies*)
+(** Type of rounding strategies*)
 type rounding =
   | Up  (** decimal digits ignored *)
   | Down  (** decimal digits ignored *)
@@ -12,28 +12,27 @@ type rounding =
       (** rounding up to number of decimal digits provided *)
   | Truncate  (** rounding down to number of decimal digits provided *)
 
-(** Separator Configuration *)
+(** Type of separator configuration *)
 module Separator : sig
   (** {1 Types} *)
   type t = private string * string option
 
-  (** Construction*)
   val make_exn : char * char option -> t
-  (** e.g. make_exn (',', Some '.') *)
+  (** [make_exn c c_opt] makes sep config, e.g. make_exn (',', Some '.') *)
 
   val fst : t -> string
-  (** Get first separator *)
+  (** [fst t] gets t's first separator *)
 
   val snd : t -> string option
-  (** Get second optional separator *)
+  (** [snd t] gets t's second optional separator *)
 end
 
-(** Printing and rounding configuration *)
+(** Type of printing and rounding configuration *)
 type printing_conf =
-  { separator: Separator.t
-  ; plus_sign: bool
-  ; num_of_digits: Uint8.t
-  ; rounding: rounding }
+  { separator: Separator.t  (** type of separator *)
+  ; plus_sign: bool  (** whether to print + sign if positive *)
+  ; num_of_digits: Uint8.t  (** num of decimal places printed *)
+  ; rounding: rounding  (** rounding strategy used *) }
 
 val make_printing_conf :
      sep:Separator.t
@@ -41,85 +40,88 @@ val make_printing_conf :
   -> num_of_digits:int
   -> rounding:rounding
   -> printing_conf
-(** Make printing and rounding configuration *)
+(** [make_printing_conf separator plus_sign num_of_digits rounding] makes a printing config *)
 
 val mark_thousands : v:int -> sep:string -> string
+(** [mark_thousands position separator] marks a thousand separator at the position specified *)
 
 val sep_comma : unit -> Separator.t
-(** Premade separator configuration, e.g. 1000,0 *)
+(** [sep_comma ()] pre-made separator configuration, e.g. 1000,0 *)
 
 val sep_comma_dot : unit -> Separator.t
-(** Premade separator configuration, e.g. 1.000,0 *)
+(** [sep_comma_dot ()] pre-made separator configuration, e.g. 1.000,0 *)
 
 val sep_comma_space : unit -> Separator.t
-(** Premade separator configuration, e.g. 1_000,0*)
+(** [sep_comma_space ()] pre-made separator configuration, e.g. 1_000,0*)
 
 val sep_dot : unit -> Separator.t
-(** Premade separator configuration, e.g. 1000.0 *)
+(** [sep_dot ()] pre-made separator configuration, e.g. 1000.0 *)
 
 val sep_dot_comma : unit -> Separator.t
-(** Premade separator configuration, e.g. 1,000.0 *)
+(** [sep_dot_comma ()] pre-made separator configuration, e.g. 1,000.0 *)
 
 val sep_dot_space : unit -> Separator.t
-(** Premade separator configuration, e.g. 1_000.0 *)
+(** [sep_dot_space ()] pre-made separator configuration, e.g. 1_000.0 *)
 
 val default_printing_conf : unit -> printing_conf
-(** Default printing configuration *)
+(** [default_printing_conf ()] makes a default printing configuration *)
 
-val q_to_decimal : printing_conf:printing_conf -> qv:Qv.t -> string
-(** Convert a rational value to string representation of a float value with a printing configuration.
+val q_to_decimal : printing_conf:printing_conf -> q:Qv.t -> string
+(** [q_to_decimal printing_conf q] converts a rational value q to string representation of a float value with a printing configuration.
     e.g. [let sep_dot_comma = Separator.make_exn ('.', Some ',') in
     let printing_conf = { separator = sep_dot_comma; plus_sign = true; num_of_digits = Uint8.of_int 4; rounding = Truncate } in
     q_to_decimal ~printing_conf: printing_conf ~qv: (Utils.make_q "-1234567/7")]
     would print "-176366.7142" *)
 
 val seal_quotient : printing_conf:printing_conf -> qv:Quotient.t -> string
-(** Convert quotient value to the string representaion of a float value with a printing configuration.
-    This should be used as the final step after all operations have been carried out. *)
+(** [seal_quotient printing_conf qv] converts a quotient value qv to the string representaion of a float value with a printing configuration.
+    This should be used as the final step after all operations have been carried out *)
 
 val seal_discrete : printing_conf:printing_conf -> dv:Discrete.t -> string
-(** Convert discrete value to the string representaion of a float value with a printing configuration.
-    This should be used as the final step after all operations have been carried out. *)
+(** [seal_discrete printing_conf dv] converts a discrete value dv to the string representaion of a float value with a printing configuration.
+    This should be used as the final step after all operations have been carried out *)
 
 val seal_exchange : printing_conf:printing_conf -> xchg:Exchange.t -> string
-(** Convert exchange value to the string representaion of a float value with a printing configuration.
-    This should be used as the final step after all operations have been carried out. *)
+(** [seal_exchange printing_conf xchg] converts an exchange value xchg to the string representaion of a float value with a printing configuration.
+    This should be used as the final step after all operations have been carried out *)
 
 val seal_scale :
   printing_conf:printing_conf -> scale:Discrete.Scale.t -> string
-(** Convert scale value to the string representaion of a float value with a printing configuration.
-    This should be used as the final step after all operations have been carried out. *)
+(** [seal_scale printing_conf scale] converts a scale value to the string representaion of a float value with a printing configuration.
+    This should be used as the final step after all operations have been carried out *)
 
 val unsafe_decimal_to_q :
   decimal:string -> sep:Separator.t -> (string, string) result
-(** Parse the string representation of a float value with printing configuration
+(** [unsafe_decimal_to_q decimal sep] parses the string representation of a float value with printing configuration
     e.g. [ let sep = Separator.make_exn ('.', Some ',') in unsafe_decimal_to_q ~decimal : "+123,456.789"]
-    would convert value to "123456.789" *)
+    would convert value to "123456.789" 
+    It is unsafe in a sense that the origin of float is deemed to
+    be unverified by default and might be as a result of lossy operations *)
 
 val unsafe_float_to_quotient :
   symbol:string -> decimal:string -> sep:Separator.t -> Quotient.t
-(** Unsafely convert a float value of string rep to quotient value.
+(** [unsafe_float_to_quotient symbol decimal sep] converts a float value of string rep to quotient value.
     It is unsafe in a sense that the origin of float is deemed to
-    be unverified by default and might be as a result of lossy operations. *)
+    be unverified by default and might be as a result of lossy operations *)
 
 val unsafe_float_to_discrete :
   scale:Discrete.Scale.t -> integer:int -> Discrete.t
-(** Unsafely convert a integer value of string rep to discrete value.
+(** [unsafe_float_to_discrete symbol decimal sep] converts an integer value of string rep to discrete value.
     It is unsafe in a sense that the origin of the integer is deemed to
-    be unverified by default and might be as a result of lossy operations. *)
+    be unverified by default and might be as a result of lossy operations *)
 
 val unsafe_float_to_exchange :
   src:string -> dst:string -> decimal:string -> sep:Separator.t -> Exchange.t
-(** Unsafely convert a float/decimal value of string rep to exchange value.
+(** [unsafe_float_to_exchange src dst decimal sep] converts a float/decimal value of string rep to exchange value.
     It is unsafe in a sense that the origin of float/decimal is deemed to
-    be unverified by default and might be as a result of lossy operations. *)
+    be unverified by default and might be as a result of lossy operations *)
 
 val unsafe_float_to_scale :
-     symbol:string
-  -> unit:string
+     sym:string
+  -> sub_unit:string
   -> decimal:string
   -> sep:Separator.t
   -> Discrete.Scale.t
-(** Unsafely convert a float/decimal value of string rep to scale value.
+(** [unsafe_float_to_scale sym sub_unit decimal sep] converts a float/decimal value of string rep to scale value.
     It is unsafe in a sense that the origin of float/decimal is deemed to
-    be unverified by default and might be as a result of lossy operations. *)
+    be unverified by default and might be as a result of lossy operations *)

--- a/lib/predefined.ml
+++ b/lib/predefined.ml
@@ -10,9 +10,12 @@ module ISO4217_AFN : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let afghani =
-      Discrete.Scale.make_scale symbol "afghani" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"afghani"
+        (make_q "1/1")
     in
-    let pul = Discrete.Scale.make_scale symbol "pul" (make_q "100/1") in
+    let pul =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pul" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"afghani" ~data:afghani ;
     Hashtbl.set table ~key:"pul" ~data:pul ;
     Some table
@@ -38,9 +41,12 @@ module ISO4217_ALL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let lek = Discrete.Scale.make_scale symbol "lek" (make_q "1/1") in
+    let lek =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lek" (make_q "1/1")
+    in
     let qindarke =
-      Discrete.Scale.make_scale symbol "qindarke" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"qindarke"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"lek" ~data:lek ;
     Hashtbl.set table ~key:"qindarke" ~data:qindarke ;
@@ -67,9 +73,12 @@ module ISO4217_DZD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
     let santeem =
-      Discrete.Scale.make_scale symbol "santeem" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"santeem"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"santeem" ~data:santeem ;
@@ -96,9 +105,12 @@ module ISO4217_AOA : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let kwanza = Discrete.Scale.make_scale symbol "kwanza" (make_q "1/1") in
+    let kwanza =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kwanza" (make_q "1/1")
+    in
     let centimo =
-      Discrete.Scale.make_scale symbol "centimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"kwanza" ~data:kwanza ;
     Hashtbl.set table ~key:"centimo" ~data:centimo ;
@@ -125,8 +137,12 @@ module ISO4217_XCD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -152,9 +168,12 @@ module ISO4217_ARS : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -181,8 +200,12 @@ module ISO4217_AMD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dram = Discrete.Scale.make_scale symbol "dram" (make_q "1/1") in
-    let luma = Discrete.Scale.make_scale symbol "luma" (make_q "100/1") in
+    let dram =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dram" (make_q "1/1")
+    in
+    let luma =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"luma" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dram" ~data:dram ;
     Hashtbl.set table ~key:"luma" ~data:luma ;
     Some table
@@ -208,8 +231,12 @@ module ISO4217_AWG : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let florin = Discrete.Scale.make_scale symbol "florin" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let florin =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"florin" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"florin" ~data:florin ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -235,8 +262,12 @@ module ISO4217_AUD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -262,8 +293,13 @@ module ISO4217_AZN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let manat = Discrete.Scale.make_scale symbol "qapik" (make_q "1/1") in
-    let qapik = Discrete.Scale.make_scale symbol "qapik" (make_q "100/1") in
+    let manat =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"qapik" (make_q "1/1")
+    in
+    let qapik =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"qapik"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"manat" ~data:manat ;
     Hashtbl.set table ~key:"qapik" ~data:qapik ;
     Some table
@@ -289,8 +325,12 @@ module ISO4217_BSD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -316,8 +356,13 @@ module ISO4217_BHD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
-    let fils = Discrete.Scale.make_scale symbol "fils" (make_q "1000/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
+    let fils =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fils"
+        (make_q "1000/1")
+    in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"fils" ~data:fils ;
     Some table
@@ -343,8 +388,13 @@ module ISO4217_BDT : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let taka = Discrete.Scale.make_scale symbol "taka" (make_q "1/1") in
-    let paisa = Discrete.Scale.make_scale symbol "paisa" (make_q "100/1") in
+    let taka =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"taka" (make_q "1/1")
+    in
+    let paisa =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"paisa"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"taka" ~data:taka ;
     Hashtbl.set table ~key:"paisa" ~data:paisa ;
     Some table
@@ -370,8 +420,12 @@ module ISO4217_BBD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -397,9 +451,13 @@ module ISO4217_BYN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let ruble = Discrete.Scale.make_scale symbol "kapiejka" (make_q "1/1") in
+    let ruble =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kapiejka"
+        (make_q "1/1")
+    in
     let kapiejka =
-      Discrete.Scale.make_scale symbol "kapiejka" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kapiejka"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"ruble" ~data:ruble ;
     Hashtbl.set table ~key:"kapiejka" ~data:kapiejka ;
@@ -426,8 +484,12 @@ module ISO4217_BZD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -453,9 +515,12 @@ module ISO4217_XOF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -482,8 +547,12 @@ module ISO4217_BMD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -510,10 +579,12 @@ module ISO4217_BTN : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let ngultrum =
-      Discrete.Scale.make_scale symbol "ngultrum" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ngultrum"
+        (make_q "100/1")
     in
     let chetrum =
-      Discrete.Scale.make_scale symbol "chetrum" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"chetrum"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"ngultrum" ~data:ngultrum ;
     Hashtbl.set table ~key:"chetrum" ~data:chetrum ;
@@ -541,10 +612,12 @@ module ISO4217_BOB : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let boliviano =
-      Discrete.Scale.make_scale symbol "boliviano" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"boliviano"
+        (make_q "1/1")
     in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"boliviano" ~data:boliviano ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -571,7 +644,9 @@ module ISO4217_BOV : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let bov = Discrete.Scale.make_scale symbol "BOV" (make_q "100/1") in
+    let bov =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"BOV" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"BOV" ~data:bov ;
     Some table
 
@@ -596,9 +671,12 @@ module ISO4217_BAM : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let mark = Discrete.Scale.make_scale symbol "mark" (make_q "1/1") in
+    let mark =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"mark" (make_q "1/1")
+    in
     let fening =
-      Discrete.Scale.make_scale symbol "fening" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fening"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"mark" ~data:mark ;
     Hashtbl.set table ~key:"fening" ~data:fening ;
@@ -625,8 +703,13 @@ module ISO4217_BWP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pula = Discrete.Scale.make_scale symbol "pula" (make_q "1/1") in
-    let thebe = Discrete.Scale.make_scale symbol "thebe" (make_q "100/1") in
+    let pula =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pula" (make_q "1/1")
+    in
+    let thebe =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"thebe"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"pula" ~data:pula ;
     Hashtbl.set table ~key:"thebe" ~data:thebe ;
     Some table
@@ -652,8 +735,12 @@ module ISO4217_NOK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let krone = Discrete.Scale.make_scale symbol "krone" (make_q "1/1") in
-    let ore = Discrete.Scale.make_scale symbol "ore" (make_q "100/1") in
+    let krone =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"krone" (make_q "1/1")
+    in
+    let ore =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ore" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"krone" ~data:krone ;
     Hashtbl.set table ~key:"ore" ~data:ore ;
     Some table
@@ -679,9 +766,12 @@ module ISO4217_BRL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let real = Discrete.Scale.make_scale symbol "real" (make_q "1/1") in
+    let real =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"real" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"real" ~data:real ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -708,8 +798,12 @@ module ISO4217_BND : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let sen = Discrete.Scale.make_scale symbol "sen" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let sen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sen" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"sen" ~data:sen ;
     Some table
@@ -735,9 +829,12 @@ module ISO4217_BGN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let lev = Discrete.Scale.make_scale symbol "lev" (make_q "1/1") in
+    let lev =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lev" (make_q "1/1")
+    in
     let stotinka =
-      Discrete.Scale.make_scale symbol "stotinka" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"stotinka"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"lev" ~data:lev ;
     Hashtbl.set table ~key:"stotinka" ~data:stotinka ;
@@ -764,9 +861,12 @@ module ISO4217_BIF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -793,9 +893,12 @@ module ISO4217_CVE : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let escudo = Discrete.Scale.make_scale symbol "escudo" (make_q "1/1") in
+    let escudo =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"escudo" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"escudo" ~data:escudo ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -822,8 +925,12 @@ module ISO4217_KHR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let riel = Discrete.Scale.make_scale symbol "r" (make_q "1/1") in
-    let sen = Discrete.Scale.make_scale symbol "sen" (make_q "100/1") in
+    let riel =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"r" (make_q "1/1")
+    in
+    let sen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sen" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"riel" ~data:riel ;
     Hashtbl.set table ~key:"sen" ~data:sen ;
     Some table
@@ -849,9 +956,12 @@ module ISO4217_XAF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -878,8 +988,12 @@ module ISO4217_CAD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -905,8 +1019,12 @@ module ISO4217_KYD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -932,9 +1050,12 @@ module ISO4217_CLP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -961,7 +1082,10 @@ module ISO4217_CLF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let clf = Discrete.Scale.make_scale symbol "CLF" (make_q "10000/1") in
+    let clf =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"CLF"
+        (make_q "10000/1")
+    in
     Hashtbl.set table ~key:"CLF" ~data:clf ;
     Some table
 
@@ -986,8 +1110,12 @@ module ISO4217_CNY : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let yuan = Discrete.Scale.make_scale symbol "yuan" (make_q "1/1") in
-    let fen = Discrete.Scale.make_scale symbol "fen" (make_q "100/1") in
+    let yuan =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"yuan" (make_q "1/1")
+    in
+    let fen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fen" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"yuan" ~data:yuan ;
     Hashtbl.set table ~key:"fen" ~data:fen ;
     Some table
@@ -1013,9 +1141,12 @@ module ISO4217_COP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1042,7 +1173,9 @@ module ISO4217_COU : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let cou = Discrete.Scale.make_scale symbol "COU" (make_q "100/1") in
+    let cou =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"COU" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"COU" ~data:cou ;
     Some table
 
@@ -1067,9 +1200,12 @@ module ISO4217_KMF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -1096,9 +1232,12 @@ module ISO4217_CDF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -1125,9 +1264,12 @@ module ISO4217_CRC : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let colon = Discrete.Scale.make_scale symbol "colon" (make_q "1/1") in
+    let colon =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"colon" (make_q "1/1")
+    in
     let centimo =
-      Discrete.Scale.make_scale symbol "centimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"colon" ~data:colon ;
     Hashtbl.set table ~key:"centimo" ~data:centimo ;
@@ -1154,9 +1296,12 @@ module ISO4217_CUP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1183,9 +1328,12 @@ module ISO4217_CUC : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1213,9 +1361,12 @@ module ISO4217_ANG : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let guilder =
-      Discrete.Scale.make_scale symbol "guilder" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"guilder"
+        (make_q "1/1")
     in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"guilder" ~data:guilder ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1241,8 +1392,13 @@ module ISO4217_CZK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let koruna = Discrete.Scale.make_scale symbol "koruna" (make_q "1/1") in
-    let haler = Discrete.Scale.make_scale symbol "haler" (make_q "100/1") in
+    let koruna =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"koruna" (make_q "1/1")
+    in
+    let haler =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"haler"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"koruna" ~data:koruna ;
     Hashtbl.set table ~key:"haler" ~data:haler ;
     Some table
@@ -1268,8 +1424,12 @@ module ISO4217_DKK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let krone = Discrete.Scale.make_scale symbol "krone" (make_q "1/1") in
-    let ore = Discrete.Scale.make_scale symbol "ore" (make_q "100/1") in
+    let krone =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"krone" (make_q "1/1")
+    in
+    let ore =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ore" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"krone" ~data:krone ;
     Hashtbl.set table ~key:"ore" ~data:ore ;
     Some table
@@ -1295,9 +1455,12 @@ module ISO4217_DJF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -1324,9 +1487,12 @@ module ISO4217_DOP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1353,9 +1519,12 @@ module ISO4217_EGP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
     let piastre =
-      Discrete.Scale.make_scale symbol "piastre" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piastre"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"piastre" ~data:piastre ;
@@ -1382,9 +1551,12 @@ module ISO4217_SVC : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let colon = Discrete.Scale.make_scale symbol "colon" (make_q "1/1") in
+    let colon =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"colon" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"colon" ~data:colon ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1411,8 +1583,12 @@ module ISO4217_ERN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let nafka = Discrete.Scale.make_scale symbol "nafka" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let nafka =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"nafka" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"nafka" ~data:nafka ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1439,9 +1615,12 @@ module ISO4217_SZL : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let lilangeni =
-      Discrete.Scale.make_scale symbol "lilangeni" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lilangeni"
+        (make_q "1/1")
     in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"lilangeni" ~data:lilangeni ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1467,9 +1646,12 @@ module ISO4217_ETB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let birr = Discrete.Scale.make_scale symbol "birr" (make_q "1/1") in
+    let birr =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"birr" (make_q "1/1")
+    in
     let santim =
-      Discrete.Scale.make_scale symbol "santim" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"santim"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"birr" ~data:birr ;
     Hashtbl.set table ~key:"santim" ~data:santim ;
@@ -1496,8 +1678,12 @@ module ISO4217_EUR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let euro = Discrete.Scale.make_scale symbol "euro" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let euro =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"euro" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"euro" ~data:euro ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1523,8 +1709,12 @@ module ISO4217_FKP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
-    let penny = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
+    let penny =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"penny" ~data:penny ;
     Some table
@@ -1550,8 +1740,12 @@ module ISO4217_FJD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1577,9 +1771,12 @@ module ISO4217_XPF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -1606,8 +1803,13 @@ module ISO4217_GBP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
-    let penny = Discrete.Scale.make_scale symbol "penny" (make_q "100/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
+    let penny =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"penny"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"penny" ~data:penny ;
     Some table
@@ -1633,8 +1835,13 @@ module ISO4217_GMD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dalasi = Discrete.Scale.make_scale symbol "dalasi" (make_q "1/1") in
-    let butut = Discrete.Scale.make_scale symbol "butut" (make_q "100/1") in
+    let dalasi =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dalasi" (make_q "1/1")
+    in
+    let butut =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"butut"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dalasi" ~data:dalasi ;
     Hashtbl.set table ~key:"butut" ~data:butut ;
     Some table
@@ -1660,8 +1867,13 @@ module ISO4217_GEL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let lari = Discrete.Scale.make_scale symbol "lari" (make_q "1/1") in
-    let tetri = Discrete.Scale.make_scale symbol "tetri" (make_q "100/1") in
+    let lari =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lari" (make_q "1/1")
+    in
+    let tetri =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tetri"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"lari" ~data:lari ;
     Hashtbl.set table ~key:"tetri" ~data:tetri ;
     Some table
@@ -1687,9 +1899,12 @@ module ISO4217_GHS : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let cedi = Discrete.Scale.make_scale symbol "cedi" (make_q "1/1") in
+    let cedi =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cedi" (make_q "1/1")
+    in
     let pesewa =
-      Discrete.Scale.make_scale symbol "pesewa" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pesewa"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"cedi" ~data:cedi ;
     Hashtbl.set table ~key:"pesewa" ~data:pesewa ;
@@ -1716,8 +1931,13 @@ module ISO4217_GIP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
-    let penny = Discrete.Scale.make_scale symbol "penny" (make_q "100/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
+    let penny =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"penny"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"penny" ~data:penny ;
     Some table
@@ -1744,10 +1964,12 @@ module ISO4217_GTQ : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let quetzal =
-      Discrete.Scale.make_scale symbol "quetzal" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"quetzal"
+        (make_q "1/1")
     in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"quetzal" ~data:quetzal ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1774,9 +1996,12 @@ module ISO4217_GNF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -1803,8 +2028,12 @@ module ISO4217_GYD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1830,9 +2059,12 @@ module ISO4217_HTG : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let gourde = Discrete.Scale.make_scale symbol "gourde" (make_q "1/1") in
+    let gourde =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"gourde" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"gourde" ~data:gourde ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -1860,10 +2092,12 @@ module ISO4217_HNL : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let lempira =
-      Discrete.Scale.make_scale symbol "lempira" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lempira"
+        (make_q "1/1")
     in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"lempira" ~data:lempira ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -1890,8 +2124,12 @@ module ISO4217_HKD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -1917,9 +2155,12 @@ module ISO4217_HUF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let forint = Discrete.Scale.make_scale symbol "forint" (make_q "1/1") in
+    let forint =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"forint" (make_q "1/1")
+    in
     let filler =
-      Discrete.Scale.make_scale symbol "filler" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"filler"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"forint" ~data:forint ;
     Hashtbl.set table ~key:"filler" ~data:filler ;
@@ -1946,8 +2187,13 @@ module ISO4217_ISK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let krona = Discrete.Scale.make_scale symbol "krona" (make_q "1/1") in
-    let eyrir = Discrete.Scale.make_scale symbol "eyrir" (make_q "100/1") in
+    let krona =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"krona" (make_q "1/1")
+    in
+    let eyrir =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"eyrir"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"krona" ~data:krona ;
     Hashtbl.set table ~key:"eyrir" ~data:eyrir ;
     Some table
@@ -1973,8 +2219,13 @@ module ISO4217_INR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupee = Discrete.Scale.make_scale symbol "rupee" (make_q "1/1") in
-    let paisa = Discrete.Scale.make_scale symbol "paisa" (make_q "100/1") in
+    let rupee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupee" (make_q "1/1")
+    in
+    let paisa =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"paisa"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupee" ~data:rupee ;
     Hashtbl.set table ~key:"paisa" ~data:paisa ;
     Some table
@@ -2000,8 +2251,12 @@ module ISO4217_IDR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupiah = Discrete.Scale.make_scale symbol "rupiah" (make_q "1/1") in
-    let sen = Discrete.Scale.make_scale symbol "sen" (make_q "100/1") in
+    let rupiah =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupiah" (make_q "1/1")
+    in
+    let sen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sen" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupiah" ~data:rupiah ;
     Hashtbl.set table ~key:"sen" ~data:sen ;
     Some table
@@ -2027,7 +2282,9 @@ module ISO4217_XDR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xdr = Discrete.Scale.make_scale symbol "XDR" (make_q "1/1") in
+    let xdr =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XDR" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"XDR" ~data:xdr ;
     Some table
 
@@ -2052,8 +2309,13 @@ module ISO4217_IRR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rial = Discrete.Scale.make_scale symbol "rial" (make_q "1/1") in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "100/1") in
+    let rial =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rial" (make_q "1/1")
+    in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rial" ~data:rial ;
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Some table
@@ -2079,8 +2341,12 @@ module ISO4217_IQD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
-    let fils = Discrete.Scale.make_scale symbol "fils" (make_q "100/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
+    let fils =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fils" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"fils" ~data:fils ;
     Some table
@@ -2106,8 +2372,13 @@ module ISO4217_ILS : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let shekel = Discrete.Scale.make_scale symbol "shekel" (make_q "1/1") in
-    let agora = Discrete.Scale.make_scale symbol "agora" (make_q "100/1") in
+    let shekel =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shekel" (make_q "1/1")
+    in
+    let agora =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"agora"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"shekel" ~data:shekel ;
     Hashtbl.set table ~key:"agora" ~data:agora ;
     Some table
@@ -2133,8 +2404,12 @@ module ISO4217_JMD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -2160,8 +2435,12 @@ module ISO4217_JPY : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let yen = Discrete.Scale.make_scale symbol "yen" (make_q "1/1") in
-    let sen = Discrete.Scale.make_scale symbol "sen" (make_q "100/1") in
+    let yen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"yen" (make_q "1/1")
+    in
+    let sen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sen" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"yen" ~data:yen ;
     Hashtbl.set table ~key:"sen" ~data:sen ;
     Some table
@@ -2187,9 +2466,12 @@ module ISO4217_JOD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
     let piastre =
-      Discrete.Scale.make_scale symbol "piastre" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piastre"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"piastre" ~data:piastre ;
@@ -2216,8 +2498,13 @@ module ISO4217_KZT : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let tenge = Discrete.Scale.make_scale symbol "tenge" (make_q "1/1") in
-    let tiyin = Discrete.Scale.make_scale symbol "tiyin" (make_q "100/1") in
+    let tenge =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tenge" (make_q "1/1")
+    in
+    let tiyin =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tiyin"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"tenge" ~data:tenge ;
     Hashtbl.set table ~key:"tiyin" ~data:tiyin ;
     Some table
@@ -2244,9 +2531,12 @@ module ISO4217_KES : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let shilling =
-      Discrete.Scale.make_scale symbol "shilling" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shilling"
+        (make_q "1/1")
     in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"shilling" ~data:shilling ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -2272,8 +2562,12 @@ module ISO4217_KPW : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let won = Discrete.Scale.make_scale symbol "won" (make_q "1/1") in
-    let chon = Discrete.Scale.make_scale symbol "chon" (make_q "100/1") in
+    let won =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"won" (make_q "1/1")
+    in
+    let chon =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"chon" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"won" ~data:won ;
     Hashtbl.set table ~key:"chon" ~data:chon ;
     Some table
@@ -2299,8 +2593,12 @@ module ISO4217_KRW : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let won = Discrete.Scale.make_scale symbol "won" (make_q "1/1") in
-    let jeon = Discrete.Scale.make_scale symbol "jeon" (make_q "100/1") in
+    let won =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"won" (make_q "1/1")
+    in
+    let jeon =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"jeon" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"won" ~data:won ;
     Hashtbl.set table ~key:"jeon" ~data:jeon ;
     Some table
@@ -2326,8 +2624,12 @@ module ISO4217_KWD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
-    let fils = Discrete.Scale.make_scale symbol "fils" (make_q "100/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
+    let fils =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fils" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"fils" ~data:fils ;
     Some table
@@ -2353,8 +2655,13 @@ module ISO4217_KGS : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let som = Discrete.Scale.make_scale symbol "som" (make_q "1/1") in
-    let tyiyn = Discrete.Scale.make_scale symbol "tyiyn" (make_q "100/1") in
+    let som =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"som" (make_q "1/1")
+    in
+    let tyiyn =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tyiyn"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"som" ~data:som ;
     Hashtbl.set table ~key:"tyiyn" ~data:tyiyn ;
     Some table
@@ -2380,8 +2687,12 @@ module ISO4217_LAK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let kip = Discrete.Scale.make_scale symbol "kip" (make_q "1/1") in
-    let att = Discrete.Scale.make_scale symbol "att" (make_q "100/1") in
+    let kip =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kip" (make_q "1/1")
+    in
+    let att =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"att" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"kip" ~data:kip ;
     Hashtbl.set table ~key:"att" ~data:att ;
     Some table
@@ -2407,9 +2718,12 @@ module ISO4217_LBP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
     let piastre =
-      Discrete.Scale.make_scale symbol "piastre" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piastre"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"piastre" ~data:piastre ;
@@ -2436,8 +2750,13 @@ module ISO4217_LSL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let loti = Discrete.Scale.make_scale symbol "loti" (make_q "1/1") in
-    let sente = Discrete.Scale.make_scale symbol "sente" (make_q "100/1") in
+    let loti =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"loti" (make_q "1/1")
+    in
+    let sente =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sente"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"loti" ~data:loti ;
     Hashtbl.set table ~key:"sente" ~data:sente ;
     Some table
@@ -2463,8 +2782,12 @@ module ISO4217_LRD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -2490,9 +2813,12 @@ module ISO4217_LYD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
     let dirham =
-      Discrete.Scale.make_scale symbol "dirham" (make_q "1000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dirham"
+        (make_q "1000/1")
     in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"dirham" ~data:dirham ;
@@ -2519,9 +2845,12 @@ module ISO4217_CHF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let rappen =
-      Discrete.Scale.make_scale symbol "rappen" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rappen"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"rappen" ~data:rappen ;
@@ -2548,8 +2877,12 @@ module ISO4217_MOP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pataca = Discrete.Scale.make_scale symbol "pataca" (make_q "1/1") in
-    let avo = Discrete.Scale.make_scale symbol "avo" (make_q "100/1") in
+    let pataca =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pataca" (make_q "1/1")
+    in
+    let avo =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"avo" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"pataca" ~data:pataca ;
     Hashtbl.set table ~key:"avo" ~data:avo ;
     Some table
@@ -2575,8 +2908,12 @@ module ISO4217_MKD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let denar = Discrete.Scale.make_scale symbol "denar" (make_q "1/1") in
-    let deni = Discrete.Scale.make_scale symbol "deni" (make_q "100/1") in
+    let denar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"denar" (make_q "1/1")
+    in
+    let deni =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"deni" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"denar" ~data:denar ;
     Hashtbl.set table ~key:"deni" ~data:deni ;
     Some table
@@ -2602,9 +2939,12 @@ module ISO4217_MGA : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let ariary = Discrete.Scale.make_scale symbol "ariary" (make_q "1/1") in
+    let ariary =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ariary" (make_q "1/1")
+    in
     let iraimbilanja =
-      Discrete.Scale.make_scale symbol "iraimbilanja" (make_q "5/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"iraimbilanja"
+        (make_q "5/1")
     in
     Hashtbl.set table ~key:"ariary" ~data:ariary ;
     Hashtbl.set table ~key:"iraimbilanja" ~data:iraimbilanja ;
@@ -2631,9 +2971,12 @@ module ISO4217_MWK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let kwacha = Discrete.Scale.make_scale symbol "kwacha" (make_q "1/1") in
+    let kwacha =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kwacha" (make_q "1/1")
+    in
     let tambala =
-      Discrete.Scale.make_scale symbol "tambala" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tambala"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"kwacha" ~data:kwacha ;
     Hashtbl.set table ~key:"tambala" ~data:tambala ;
@@ -2661,9 +3004,12 @@ module ISO4217_MYR : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let ringgit =
-      Discrete.Scale.make_scale symbol "ringgit" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ringgit"
+        (make_q "1/1")
     in
-    let sen = Discrete.Scale.make_scale symbol "sen" (make_q "100/1") in
+    let sen =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sen" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"ringgit" ~data:ringgit ;
     Hashtbl.set table ~key:"sen" ~data:sen ;
     Some table
@@ -2690,9 +3036,13 @@ module ISO4217_MVR : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let rufiyaa =
-      Discrete.Scale.make_scale symbol "rufiyaa" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rufiyaa"
+        (make_q "1/1")
     in
-    let laari = Discrete.Scale.make_scale symbol "laari" (make_q "100/1") in
+    let laari =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"laari"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rufiyaa" ~data:rufiyaa ;
     Hashtbl.set table ~key:"laari" ~data:laari ;
     Some table
@@ -2718,8 +3068,12 @@ module ISO4217_MUR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupee = Discrete.Scale.make_scale symbol "rupee" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let rupee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupee" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupee" ~data:rupee ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -2745,7 +3099,9 @@ module ISO4217_XUA : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xua = Discrete.Scale.make_scale symbol "XUA" (make_q "1/1") in
+    let xua =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XUA" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"xua" ~data:xua ;
     Some table
 
@@ -2770,9 +3126,12 @@ module ISO4217_MXN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -2799,7 +3158,9 @@ module ISO4217_MXV : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let mxv = Discrete.Scale.make_scale symbol "MXV" (make_q "100/1") in
+    let mxv =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"MXV" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"mxv" ~data:mxv ;
     Some table
 
@@ -2824,8 +3185,12 @@ module ISO4217_MDL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let leu = Discrete.Scale.make_scale symbol "leu" (make_q "1/1") in
-    let ban = Discrete.Scale.make_scale symbol "ban" (make_q "100/1") in
+    let leu =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"leu" (make_q "1/1")
+    in
+    let ban =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ban" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"leu" ~data:leu ;
     Hashtbl.set table ~key:"ban" ~data:ban ;
     Some table
@@ -2851,8 +3216,13 @@ module ISO4217_MNT : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let tugrik = Discrete.Scale.make_scale symbol "tugrik" (make_q "1/1") in
-    let mongo = Discrete.Scale.make_scale symbol "mongo" (make_q "100/1") in
+    let tugrik =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tugrik" (make_q "1/1")
+    in
+    let mongo =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"mongo"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"tugrik" ~data:tugrik ;
     Hashtbl.set table ~key:"mongo" ~data:mongo ;
     Some table
@@ -2878,9 +3248,12 @@ module ISO4217_MAD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dirham = Discrete.Scale.make_scale symbol "dirham" (make_q "1/1") in
+    let dirham =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dirham" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"dirham" ~data:dirham ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -2907,8 +3280,12 @@ module ISO4217_MMK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let kyat = Discrete.Scale.make_scale symbol "kyat" (make_q "1/1") in
-    let pya = Discrete.Scale.make_scale symbol "pya" (make_q "100/1") in
+    let kyat =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kyat" (make_q "1/1")
+    in
+    let pya =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pya" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"kyat" ~data:kyat ;
     Hashtbl.set table ~key:"pya" ~data:pya ;
     Some table
@@ -2934,8 +3311,12 @@ module ISO4217_NAD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -2961,8 +3342,13 @@ module ISO4217_NPR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupee = Discrete.Scale.make_scale symbol "rupee" (make_q "1/1") in
-    let paisa = Discrete.Scale.make_scale symbol "paisa" (make_q "100/1") in
+    let rupee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupee" (make_q "1/1")
+    in
+    let paisa =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"paisa"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupee" ~data:rupee ;
     Hashtbl.set table ~key:"paisa" ~data:paisa ;
     Some table
@@ -2988,8 +3374,12 @@ module ISO4217_NZD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3016,10 +3406,12 @@ module ISO4217_NIO : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let cordoba =
-      Discrete.Scale.make_scale symbol "cordoba" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cordoba"
+        (make_q "1/1")
     in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"cordoba" ~data:cordoba ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -3046,8 +3438,12 @@ module ISO4217_NGN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let naira = Discrete.Scale.make_scale symbol "naira" (make_q "1/1") in
-    let kobo = Discrete.Scale.make_scale symbol "kobo" (make_q "100/1") in
+    let naira =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"naira" (make_q "1/1")
+    in
+    let kobo =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kobo" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"naira" ~data:naira ;
     Hashtbl.set table ~key:"kobo" ~data:kobo ;
     Some table
@@ -3073,8 +3469,13 @@ module ISO4217_OMR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rial = Discrete.Scale.make_scale symbol "rial" (make_q "1/1") in
-    let baisa = Discrete.Scale.make_scale symbol "baisa" (make_q "100/1") in
+    let rial =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rial" (make_q "1/1")
+    in
+    let baisa =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"baisa"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rial" ~data:rial ;
     Hashtbl.set table ~key:"baisa" ~data:baisa ;
     Some table
@@ -3100,8 +3501,13 @@ module ISO4217_PKR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupee = Discrete.Scale.make_scale symbol "rupee" (make_q "1/1") in
-    let paisa = Discrete.Scale.make_scale symbol "paisa" (make_q "100/1") in
+    let rupee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupee" (make_q "1/1")
+    in
+    let paisa =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"paisa"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupee" ~data:rupee ;
     Hashtbl.set table ~key:"paisa" ~data:paisa ;
     Some table
@@ -3127,9 +3533,12 @@ module ISO4217_PAB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let balboa = Discrete.Scale.make_scale symbol "balboa" (make_q "1/1") in
+    let balboa =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"balboa" (make_q "1/1")
+    in
     let centesimo =
-      Discrete.Scale.make_scale symbol "centesimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centesimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"balboa" ~data:balboa ;
     Hashtbl.set table ~key:"centesimo" ~data:centesimo ;
@@ -3156,8 +3565,12 @@ module ISO4217_PGK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let kina = Discrete.Scale.make_scale symbol "kina" (make_q "1/1") in
-    let toea = Discrete.Scale.make_scale symbol "toea" (make_q "100/1") in
+    let kina =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kina" (make_q "1/1")
+    in
+    let toea =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"toea" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"kina" ~data:kina ;
     Hashtbl.set table ~key:"toea" ~data:toea ;
     Some table
@@ -3184,10 +3597,12 @@ module ISO4217_PYG : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let guarani =
-      Discrete.Scale.make_scale symbol "guarani" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"guarani"
+        (make_q "1/1")
     in
     let centimo =
-      Discrete.Scale.make_scale symbol "centimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"guarani" ~data:guarani ;
     Hashtbl.set table ~key:"centimo" ~data:centimo ;
@@ -3214,9 +3629,12 @@ module ISO4217_PEN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let sol = Discrete.Scale.make_scale symbol "sol" (make_q "1/1") in
+    let sol =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sol" (make_q "1/1")
+    in
     let centimo =
-      Discrete.Scale.make_scale symbol "centimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"sol" ~data:sol ;
     Hashtbl.set table ~key:"centimo" ~data:centimo ;
@@ -3243,9 +3661,12 @@ module ISO4217_PHP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centavo =
-      Discrete.Scale.make_scale symbol "centavo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centavo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centavo" ~data:centavo ;
@@ -3272,8 +3693,13 @@ module ISO4217_PLN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let zloty = Discrete.Scale.make_scale symbol "zloty" (make_q "1/1") in
-    let grosz = Discrete.Scale.make_scale symbol "grosz" (make_q "100/1") in
+    let zloty =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"zloty" (make_q "1/1")
+    in
+    let grosz =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"grosz"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"zloty" ~data:zloty ;
     Hashtbl.set table ~key:"grosz" ~data:grosz ;
     Some table
@@ -3299,9 +3725,12 @@ module ISO4217_QAR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rial = Discrete.Scale.make_scale symbol "rial" (make_q "1/1") in
+    let rial =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rial" (make_q "1/1")
+    in
     let dirham =
-      Discrete.Scale.make_scale symbol "dirham" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dirham"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"rial" ~data:rial ;
     Hashtbl.set table ~key:"dirham" ~data:dirham ;
@@ -3328,8 +3757,12 @@ module ISO4217_RON : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let leu = Discrete.Scale.make_scale symbol "leu" (make_q "1/1") in
-    let ban = Discrete.Scale.make_scale symbol "ban" (make_q "100/1") in
+    let leu =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"leu" (make_q "1/1")
+    in
+    let ban =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ban" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"leu" ~data:leu ;
     Hashtbl.set table ~key:"ban" ~data:ban ;
     Some table
@@ -3355,8 +3788,13 @@ module ISO4217_RUB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let ruble = Discrete.Scale.make_scale symbol "ruble" (make_q "1/1") in
-    let kopek = Discrete.Scale.make_scale symbol "kopek" (make_q "100/1") in
+    let ruble =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ruble" (make_q "1/1")
+    in
+    let kopek =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kopek"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"ruble" ~data:ruble ;
     Hashtbl.set table ~key:"kopek" ~data:kopek ;
     Some table
@@ -3382,9 +3820,12 @@ module ISO4217_RWF : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let franc = Discrete.Scale.make_scale symbol "franc" (make_q "1/1") in
+    let franc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"franc" (make_q "1/1")
+    in
     let centime =
-      Discrete.Scale.make_scale symbol "centime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"franc" ~data:franc ;
     Hashtbl.set table ~key:"centime" ~data:centime ;
@@ -3411,8 +3852,13 @@ module ISO4217_SHP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
-    let penny = Discrete.Scale.make_scale symbol "penny" (make_q "100/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
+    let penny =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"penny"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"penny" ~data:penny ;
     Some table
@@ -3438,8 +3884,12 @@ module ISO4217_WST : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let tala = Discrete.Scale.make_scale symbol "tala" (make_q "1/1") in
-    let sene = Discrete.Scale.make_scale symbol "sene" (make_q "100/1") in
+    let tala =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tala" (make_q "1/1")
+    in
+    let sene =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sene" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"tala" ~data:tala ;
     Hashtbl.set table ~key:"sene" ~data:sene ;
     Some table
@@ -3465,9 +3915,12 @@ module ISO4217_STN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dobra = Discrete.Scale.make_scale symbol "dobra" (make_q "1/1") in
+    let dobra =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dobra" (make_q "1/1")
+    in
     let centimos =
-      Discrete.Scale.make_scale symbol "centimos" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimos"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"dobra" ~data:dobra ;
     Hashtbl.set table ~key:"centimos" ~data:centimos ;
@@ -3494,9 +3947,12 @@ module ISO4217_SAR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let riyal = Discrete.Scale.make_scale symbol "riyal" (make_q "1/1") in
+    let riyal =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"riyal" (make_q "1/1")
+    in
     let halala =
-      Discrete.Scale.make_scale symbol "halala" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"halala"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"riyal" ~data:riyal ;
     Hashtbl.set table ~key:"halala" ~data:halala ;
@@ -3523,8 +3979,12 @@ module ISO4217_RSD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
-    let para = Discrete.Scale.make_scale symbol "para" (make_q "100/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
+    let para =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"para" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"para" ~data:para ;
     Some table
@@ -3550,8 +4010,12 @@ module ISO4217_SCR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupee = Discrete.Scale.make_scale symbol "rupee" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let rupee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupee" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupee" ~data:rupee ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3577,8 +4041,12 @@ module ISO4217_SLL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let leone = Discrete.Scale.make_scale symbol "leone" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let leone =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"leone" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"leone" ~data:leone ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3604,8 +4072,12 @@ module ISO4217_SLE : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let leone = Discrete.Scale.make_scale symbol "leone" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let leone =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"leone" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"leone" ~data:leone ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3631,8 +4103,12 @@ module ISO4217_SGD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3658,7 +4134,9 @@ module ISO4217_XSU : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xsu = Discrete.Scale.make_scale symbol "XSU" (make_q "1/1") in
+    let xsu =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XSU" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"xsu" ~data:xsu ;
     Some table
 
@@ -3683,8 +4161,12 @@ module ISO4217_SBD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3711,9 +4193,12 @@ module ISO4217_SOS : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let shilling =
-      Discrete.Scale.make_scale symbol "shilling" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shilling"
+        (make_q "1/1")
     in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"shilling" ~data:shilling ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3739,8 +4224,12 @@ module ISO4217_ZAR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rand = Discrete.Scale.make_scale symbol "rand" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let rand =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rand" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rand" ~data:rand ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3766,9 +4255,12 @@ module ISO4217_SSP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
     let piastre =
-      Discrete.Scale.make_scale symbol "piastre" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piastre"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"piastre" ~data:piastre ;
@@ -3795,8 +4287,12 @@ module ISO4217_LKR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rupee = Discrete.Scale.make_scale symbol "rupee" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let rupee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rupee" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rupee" ~data:rupee ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3822,9 +4318,12 @@ module ISO4217_SDG : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
     let piastre =
-      Discrete.Scale.make_scale symbol "piastre" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piastre"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"piastre" ~data:piastre ;
@@ -3851,8 +4350,12 @@ module ISO4217_SRD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3878,8 +4381,12 @@ module ISO4217_SEK : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let krona = Discrete.Scale.make_scale symbol "krona" (make_q "1/1") in
-    let ore = Discrete.Scale.make_scale symbol "ore" (make_q "100/1") in
+    let krona =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"krona" (make_q "1/1")
+    in
+    let ore =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ore" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"krona" ~data:krona ;
     Hashtbl.set table ~key:"ore" ~data:ore ;
     Some table
@@ -3905,7 +4412,9 @@ module ISO4217_CHE : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let che = Discrete.Scale.make_scale symbol "CHE" (make_q "100/1") in
+    let che =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"CHE" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"che" ~data:che ;
     Some table
 
@@ -3930,9 +4439,12 @@ module ISO4217_SYP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let pound = Discrete.Scale.make_scale symbol "pound" (make_q "1/1") in
+    let pound =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pound" (make_q "1/1")
+    in
     let piastre =
-      Discrete.Scale.make_scale symbol "piastre" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piastre"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"pound" ~data:pound ;
     Hashtbl.set table ~key:"piastre" ~data:piastre ;
@@ -3959,8 +4471,12 @@ module ISO4217_TWD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -3986,8 +4502,13 @@ module ISO4217_TJS : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let somoni = Discrete.Scale.make_scale symbol "somoni" (make_q "1/1") in
-    let diram = Discrete.Scale.make_scale symbol "diram" (make_q "100/1") in
+    let somoni =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"somoni" (make_q "1/1")
+    in
+    let diram =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"diram"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"somoni" ~data:somoni ;
     Hashtbl.set table ~key:"diram" ~data:diram ;
     Some table
@@ -4014,9 +4535,12 @@ module ISO4217_TZS : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let shilling =
-      Discrete.Scale.make_scale symbol "shilling" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shilling"
+        (make_q "1/1")
     in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"shilling" ~data:shilling ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -4042,9 +4566,12 @@ module ISO4217_THB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let baht = Discrete.Scale.make_scale symbol "baht" (make_q "1/1") in
+    let baht =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"baht" (make_q "1/1")
+    in
     let satang =
-      Discrete.Scale.make_scale symbol "satang" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"satang"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"baht" ~data:baht ;
     Hashtbl.set table ~key:"satang" ~data:satang ;
@@ -4071,9 +4598,13 @@ module ISO4217_TOP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let paanga = Discrete.Scale.make_scale symbol "pa'anga" (make_q "1/1") in
+    let paanga =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"pa'anga"
+        (make_q "1/1")
+    in
     let seniti =
-      Discrete.Scale.make_scale symbol "seniti" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"seniti"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"paanga" ~data:paanga ;
     Hashtbl.set table ~key:"seniti" ~data:seniti ;
@@ -4100,8 +4631,12 @@ module ISO4217_TTD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -4127,9 +4662,12 @@ module ISO4217_TND : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dinar = Discrete.Scale.make_scale symbol "dinar" (make_q "1/1") in
+    let dinar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dinar" (make_q "1/1")
+    in
     let millime =
-      Discrete.Scale.make_scale symbol "millime" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"millime"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"dinar" ~data:dinar ;
     Hashtbl.set table ~key:"millime" ~data:millime ;
@@ -4156,8 +4694,13 @@ module ISO4217_TRY : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let lira = Discrete.Scale.make_scale symbol "lira" (make_q "1/1") in
-    let kurus = Discrete.Scale.make_scale symbol "kurus" (make_q "100/1") in
+    let lira =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lira" (make_q "1/1")
+    in
+    let kurus =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kurus"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"kurus" ~data:lira ;
     Hashtbl.set table ~key:"kurus" ~data:kurus ;
     Some table
@@ -4183,9 +4726,12 @@ module ISO4217_TMT : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let manat = Discrete.Scale.make_scale symbol "manat" (make_q "1/1") in
+    let manat =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"manat" (make_q "1/1")
+    in
     let tennesi =
-      Discrete.Scale.make_scale symbol "tennesi" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tennesi"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"manat" ~data:manat ;
     Hashtbl.set table ~key:"tennesi" ~data:tennesi ;
@@ -4213,9 +4759,12 @@ module ISO4217_UGX : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let shilling =
-      Discrete.Scale.make_scale symbol "shilling" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shilling"
+        (make_q "1/1")
     in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"shilling" ~data:shilling ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -4242,10 +4791,12 @@ module ISO4217_UAH : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let hryvnia =
-      Discrete.Scale.make_scale symbol "hryvnia" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"hryvnia"
+        (make_q "1/1")
     in
     let kopiyka =
-      Discrete.Scale.make_scale symbol "kopiyka" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kopiyka"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"hryvnia" ~data:hryvnia ;
     Hashtbl.set table ~key:"kopiyka" ~data:kopiyka ;
@@ -4272,8 +4823,12 @@ module ISO4217_AED : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dirham = Discrete.Scale.make_scale symbol "dirham" (make_q "1/1") in
-    let fils = Discrete.Scale.make_scale symbol "fils" (make_q "100/1") in
+    let dirham =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dirham" (make_q "1/1")
+    in
+    let fils =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fils" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dirham" ~data:dirham ;
     Hashtbl.set table ~key:"fils" ~data:fils ;
     Some table
@@ -4299,8 +4854,12 @@ module ISO4217_USD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -4326,8 +4885,12 @@ module ISO4217_USN : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -4353,9 +4916,12 @@ module ISO4217_UYU : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let peso = Discrete.Scale.make_scale symbol "peso" (make_q "1/1") in
+    let peso =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"peso" (make_q "1/1")
+    in
     let centesimo =
-      Discrete.Scale.make_scale symbol "centesimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centesimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"peso" ~data:peso ;
     Hashtbl.set table ~key:"centesimo" ~data:centesimo ;
@@ -4382,7 +4948,9 @@ module ISO4217_UYI : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let uyi = Discrete.Scale.make_scale symbol "UYI" (make_q "1/1") in
+    let uyi =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"UYI" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"uyi" ~data:uyi ;
     Some table
 
@@ -4407,7 +4975,10 @@ module ISO4217_UYW : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let uyw = Discrete.Scale.make_scale symbol "UYW" (make_q "10000/1") in
+    let uyw =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"UYW"
+        (make_q "10000/1")
+    in
     Hashtbl.set table ~key:"uyw" ~data:uyw ;
     Some table
 
@@ -4432,8 +5003,13 @@ module ISO4217_UZS : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let sum = Discrete.Scale.make_scale symbol "sum" (make_q "1/1") in
-    let tiyin = Discrete.Scale.make_scale symbol "tiyin" (make_q "100/1") in
+    let sum =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sum" (make_q "1/1")
+    in
+    let tiyin =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tiyin"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"sum" ~data:sum ;
     Hashtbl.set table ~key:"tiyin" ~data:tiyin ;
     Some table
@@ -4459,7 +5035,9 @@ module ISO4217_VUV : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let vatu = Discrete.Scale.make_scale symbol "vatu" (make_q "1/1") in
+    let vatu =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"vatu" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"vatu" ~data:vatu ;
     Some table
 
@@ -4485,10 +5063,12 @@ module ISO4217_VES : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let bolivar =
-      Discrete.Scale.make_scale symbol "bolivar" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"bolivar"
+        (make_q "1/1")
     in
     let centimo =
-      Discrete.Scale.make_scale symbol "centimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"bolivar" ~data:bolivar ;
     Hashtbl.set table ~key:"centimo" ~data:centimo ;
@@ -4516,10 +5096,12 @@ module ISO4217_VED : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let bolivar =
-      Discrete.Scale.make_scale symbol "bolivar" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"bolivar"
+        (make_q "1/1")
     in
     let centimo =
-      Discrete.Scale.make_scale symbol "centimo" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centimo"
+        (make_q "100/1")
     in
     Hashtbl.set table ~key:"bolivar" ~data:bolivar ;
     Hashtbl.set table ~key:"centimo" ~data:centimo ;
@@ -4546,8 +5128,12 @@ module ISO4217_VND : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dong = Discrete.Scale.make_scale symbol "dong" (make_q "1/1") in
-    let hao = Discrete.Scale.make_scale symbol "hao" (make_q "100/1") in
+    let dong =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dong" (make_q "1/1")
+    in
+    let hao =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"hao" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dong" ~data:dong ;
     Hashtbl.set table ~key:"hao" ~data:hao ;
     Some table
@@ -4573,8 +5159,12 @@ module ISO4217_YER : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let rial = Discrete.Scale.make_scale symbol "rial" (make_q "1/1") in
-    let fils = Discrete.Scale.make_scale symbol "fils" (make_q "100/1") in
+    let rial =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"rial" (make_q "1/1")
+    in
+    let fils =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"fils" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"rial" ~data:rial ;
     Hashtbl.set table ~key:"fils" ~data:fils ;
     Some table
@@ -4600,8 +5190,13 @@ module ISO4217_ZMW : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let kwacha = Discrete.Scale.make_scale symbol "kwacha" (make_q "1/1") in
-    let ngwee = Discrete.Scale.make_scale symbol "ngwee" (make_q "100/1") in
+    let kwacha =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kwacha" (make_q "1/1")
+    in
+    let ngwee =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ngwee"
+        (make_q "100/1")
+    in
     Hashtbl.set table ~key:"ngwee" ~data:kwacha ;
     Hashtbl.set table ~key:"ngwee" ~data:ngwee ;
     Some table
@@ -4627,8 +5222,12 @@ module ISO4217_ZWL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dollar = Discrete.Scale.make_scale symbol "dollar" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let dollar =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dollar" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"dollar" ~data:dollar ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -4654,7 +5253,9 @@ module ISO4217_XBA : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xba = Discrete.Scale.make_scale symbol "XBA" (make_q "1/1") in
+    let xba =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XBA" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"xba" ~data:xba ;
     Some table
 
@@ -4679,7 +5280,9 @@ module ISO4217_XBB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xbb = Discrete.Scale.make_scale symbol "XBB" (make_q "1/1") in
+    let xbb =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XBB" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"xbb" ~data:xbb ;
     Some table
 
@@ -4704,7 +5307,9 @@ module ISO4217_XBC : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xbc = Discrete.Scale.make_scale symbol "XBC" (make_q "1/1") in
+    let xbc =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XBC" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"xbc" ~data:xbc ;
     Some table
 
@@ -4730,7 +5335,9 @@ module ISO4217_XBD : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let xbd = Discrete.Scale.make_scale symbol "XBD" (make_q "1/1") in
+    let xbd =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"XBD" (make_q "1/1")
+    in
     Hashtbl.set table ~key:"xbd" ~data:xbd ;
     Some table
 
@@ -4778,24 +5385,32 @@ module ISO4217_XAU : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let troy_ounce =
-      Discrete.Scale.make_scale symbol "troy-ounce" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"troy-ounce"
+        (make_q "1/1")
     in
-    let grain = Discrete.Scale.make_scale symbol "grain" (make_q "480/1") in
+    let grain =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"grain"
+        (make_q "480/1")
+    in
     let milligrain =
-      Discrete.Scale.make_scale symbol "milligrain" (make_q "480000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligrain"
+        (make_q "480000/1")
     in
     let kilogram =
-      Discrete.Scale.make_scale symbol "kilogram"
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kilogram"
         (make_q "31103477/1000000000")
     in
     let gram =
-      Discrete.Scale.make_scale symbol "gram" (make_q "31103477/1000000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"gram"
+        (make_q "31103477/1000000")
     in
     let milligram =
-      Discrete.Scale.make_scale symbol "milligram" (make_q "31103477/1000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligram"
+        (make_q "31103477/1000")
     in
     let microgram =
-      Discrete.Scale.make_scale symbol "microgram" (make_q "31103477/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"microgram"
+        (make_q "31103477/1")
     in
     Hashtbl.set table ~key:"troy-ounce" ~data:troy_ounce ;
     Hashtbl.set table ~key:"grain" ~data:grain ;
@@ -4828,24 +5443,32 @@ module ISO4217_XPD : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let troy_ounce =
-      Discrete.Scale.make_scale symbol "troy-ounce" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"troy-ounce"
+        (make_q "1/1")
     in
-    let grain = Discrete.Scale.make_scale symbol "grain" (make_q "480/1") in
+    let grain =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"grain"
+        (make_q "480/1")
+    in
     let milligrain =
-      Discrete.Scale.make_scale symbol "milligrain" (make_q "480000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligrain"
+        (make_q "480000/1")
     in
     let kilogram =
-      Discrete.Scale.make_scale symbol "kilogram"
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kilogram"
         (make_q "31103477/1000000000")
     in
     let gram =
-      Discrete.Scale.make_scale symbol "gram" (make_q "31103477/1000000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"gram"
+        (make_q "31103477/1000000")
     in
     let milligram =
-      Discrete.Scale.make_scale symbol "milligram" (make_q "31103477/1000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligram"
+        (make_q "31103477/1000")
     in
     let microgram =
-      Discrete.Scale.make_scale symbol "microgram" (make_q "31103477/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"microgram"
+        (make_q "31103477/1")
     in
     Hashtbl.set table ~key:"troy-ounce" ~data:troy_ounce ;
     Hashtbl.set table ~key:"grain" ~data:grain ;
@@ -4878,24 +5501,32 @@ module ISO4217_XPT : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let troy_ounce =
-      Discrete.Scale.make_scale symbol "troy-ounce" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"troy-ounce"
+        (make_q "1/1")
     in
-    let grain = Discrete.Scale.make_scale symbol "grain" (make_q "480/1") in
+    let grain =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"grain"
+        (make_q "480/1")
+    in
     let milligrain =
-      Discrete.Scale.make_scale symbol "milligrain" (make_q "480000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligrain"
+        (make_q "480000/1")
     in
     let kilogram =
-      Discrete.Scale.make_scale symbol "kilogram"
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kilogram"
         (make_q "31103477/1000000000")
     in
     let gram =
-      Discrete.Scale.make_scale symbol "gram" (make_q "31103477/1000000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"gram"
+        (make_q "31103477/1000000")
     in
     let milligram =
-      Discrete.Scale.make_scale symbol "milligram" (make_q "31103477/1000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligram"
+        (make_q "31103477/1000")
     in
     let microgram =
-      Discrete.Scale.make_scale symbol "microgram" (make_q "31103477/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"microgram"
+        (make_q "31103477/1")
     in
     Hashtbl.set table ~key:"troy-ounce" ~data:troy_ounce ;
     Hashtbl.set table ~key:"grain" ~data:grain ;
@@ -4928,24 +5559,32 @@ module ISO4217_XAG : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let troy_ounce =
-      Discrete.Scale.make_scale symbol "troy-ounce" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"troy-ounce"
+        (make_q "1/1")
     in
-    let grain = Discrete.Scale.make_scale symbol "grain" (make_q "480/1") in
+    let grain =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"grain"
+        (make_q "480/1")
+    in
     let milligrain =
-      Discrete.Scale.make_scale symbol "milligrain" (make_q "480000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligrain"
+        (make_q "480000/1")
     in
     let kilogram =
-      Discrete.Scale.make_scale symbol "kilogram"
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kilogram"
         (make_q "31103477/1000000000")
     in
     let gram =
-      Discrete.Scale.make_scale symbol "gram" (make_q "31103477/1000000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"gram"
+        (make_q "31103477/1000000")
     in
     let milligram =
-      Discrete.Scale.make_scale symbol "milligram" (make_q "31103477/1000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milligram"
+        (make_q "31103477/1000")
     in
     let microgram =
-      Discrete.Scale.make_scale symbol "microgram" (make_q "31103477/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"microgram"
+        (make_q "31103477/1")
     in
     Hashtbl.set table ~key:"troy-ounce" ~data:troy_ounce ;
     Hashtbl.set table ~key:"grain" ~data:grain ;
@@ -4978,13 +5617,16 @@ module Crypto_BTC : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let bitcoin =
-      Discrete.Scale.make_scale symbol "bitcoin" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"bitcoin"
+        (make_q "1/1")
     in
     let millibitcoin =
-      Discrete.Scale.make_scale symbol "millibitcoin" (make_q "1000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"millibitcoin"
+        (make_q "1000/1")
     in
     let satoshi =
-      Discrete.Scale.make_scale symbol "satoshi" (make_q "100000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"satoshi"
+        (make_q "100000000/1")
     in
     Hashtbl.set table ~key:"bitcoin" ~data:bitcoin ;
     Hashtbl.set table ~key:"millibitcoin" ~data:millibitcoin ;
@@ -5012,39 +5654,52 @@ module Crypto_ETH : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let ether = Discrete.Scale.make_scale symbol "ether" (make_q "1/1") in
-    let kwei = Discrete.Scale.make_scale symbol "kwei" (make_q "1000/1") in
+    let ether =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ether" (make_q "1/1")
+    in
+    let kwei =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"kwei"
+        (make_q "1000/1")
+    in
     let babbage =
-      Discrete.Scale.make_scale symbol "babbage" (make_q "1000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"babbage"
+        (make_q "1000/1")
     in
     let mwei =
-      Discrete.Scale.make_scale symbol "mwei" (make_q "1000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"mwei"
+        (make_q "1000000/1")
     in
     let lovelace =
-      Discrete.Scale.make_scale symbol "lovelace" (make_q "1000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lovelace"
+        (make_q "1000000/1")
     in
     let gwei =
-      Discrete.Scale.make_scale symbol "gwei" (make_q "1000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"gwei"
+        (make_q "1000000000/1")
     in
     let shannon =
-      Discrete.Scale.make_scale symbol "shannon" (make_q "1000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shannon"
+        (make_q "1000000000/1")
     in
     let microether =
-      Discrete.Scale.make_scale symbol "microether"
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"microether"
         (make_q "1000000000000/1")
     in
     let szabo =
-      Discrete.Scale.make_scale symbol "szabo" (make_q "1000000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"szabo"
+        (make_q "1000000000000/1")
     in
     let finney =
-      Discrete.Scale.make_scale symbol "finney" (make_q "1000000000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"finney"
+        (make_q "1000000000000000/1")
     in
     let milliether =
-      Discrete.Scale.make_scale symbol "milliether"
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"milliether"
         (make_q "1000000000000000/1")
     in
     let wei =
-      Discrete.Scale.make_scale symbol "wei" (make_q "1000000000000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"wei"
+        (make_q "1000000000000000000/1")
     in
     Hashtbl.set table ~key:"ether" ~data:ether ;
     Hashtbl.set table ~key:"kwei" ~data:kwei ;
@@ -5081,9 +5736,12 @@ module Crypto_BNB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let bnb = Discrete.Scale.make_scale symbol "bnb" (make_q "1/1") in
+    let bnb =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"bnb" (make_q "1/1")
+    in
     let jager =
-      Discrete.Scale.make_scale symbol "jager" (make_q "100000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"jager"
+        (make_q "100000000/1")
     in
     Hashtbl.set table ~key:"bnb" ~data:bnb ;
     Hashtbl.set table ~key:"jager" ~data:jager ;
@@ -5110,8 +5768,12 @@ module Crypto_USDT : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let usdt = Discrete.Scale.make_scale symbol "usdt" (make_q "1/1") in
-    let cent = Discrete.Scale.make_scale symbol "cent" (make_q "100/1") in
+    let usdt =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"usdt" (make_q "1/1")
+    in
+    let cent =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"cent" (make_q "100/1")
+    in
     Hashtbl.set table ~key:"usdt" ~data:usdt ;
     Hashtbl.set table ~key:"cent" ~data:cent ;
     Some table
@@ -5137,9 +5799,12 @@ module Crypto_ADA : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let ada = Discrete.Scale.make_scale symbol "ada" (make_q "1/1") in
+    let ada =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ada" (make_q "1/1")
+    in
     let lovelace =
-      Discrete.Scale.make_scale symbol "lovelace" (make_q "1000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lovelace"
+        (make_q "1000000/1")
     in
     Hashtbl.set table ~key:"ada" ~data:ada ;
     Hashtbl.set table ~key:"lovelace" ~data:lovelace ;
@@ -5166,9 +5831,12 @@ module Crypto_DOGE : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let doge = Discrete.Scale.make_scale symbol "doge" (make_q "1/1") in
+    let doge =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"doge" (make_q "1/1")
+    in
     let koinu =
-      Discrete.Scale.make_scale symbol "koinu" (make_q "100000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"koinu"
+        (make_q "100000000/1")
     in
     Hashtbl.set table ~key:"doge" ~data:doge ;
     Hashtbl.set table ~key:"koinu" ~data:koinu ;
@@ -5196,11 +5864,16 @@ module Crypto_LTC : Custom = struct
   let units =
     let table = Hashtbl.create (module String) in
     let litecoin =
-      Discrete.Scale.make_scale symbol "litecoin" (make_q "1/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"litecoin"
+        (make_q "1/1")
     in
-    let lite = Discrete.Scale.make_scale symbol "lite" (make_q "1000/1") in
+    let lite =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lite"
+        (make_q "1000/1")
+    in
     let photon =
-      Discrete.Scale.make_scale symbol "lite" (make_q "100000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lite"
+        (make_q "100000000/1")
     in
     Hashtbl.set table ~key:"litecoin" ~data:litecoin ;
     Hashtbl.set table ~key:"lite" ~data:lite ;
@@ -5228,9 +5901,12 @@ module Crypto_XRP : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let ripple = Discrete.Scale.make_scale symbol "ripple" (make_q "1/1") in
+    let ripple =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"ripple" (make_q "1/1")
+    in
     let drop =
-      Discrete.Scale.make_scale symbol "drop" (make_q "1000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"drop"
+        (make_q "1000000/1")
     in
     Hashtbl.set table ~key:"ripple" ~data:ripple ;
     Hashtbl.set table ~key:"drop" ~data:drop ;
@@ -5257,24 +5933,32 @@ module Crypto_XMR : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let monero = Discrete.Scale.make_scale symbol "monero" (make_q "1/1") in
+    let monero =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"monero" (make_q "1/1")
+    in
     let decinero =
-      Discrete.Scale.make_scale symbol "decinero" (make_q "10/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"decinero"
+        (make_q "10/1")
     in
     let centinero =
-      Discrete.Scale.make_scale symbol "centinero" (make_q "100/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"centinero"
+        (make_q "100/1")
     in
     let millinero =
-      Discrete.Scale.make_scale symbol "millinero" (make_q "1000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"millinero"
+        (make_q "1000/1")
     in
     let micronero =
-      Discrete.Scale.make_scale symbol "micronero" (make_q "1000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"micronero"
+        (make_q "1000000/1")
     in
     let nanonero =
-      Discrete.Scale.make_scale symbol "nanonero" (make_q "1000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"nanonero"
+        (make_q "1000000000/1")
     in
     let piconero =
-      Discrete.Scale.make_scale symbol "piconero" (make_q "1000000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"piconero"
+        (make_q "1000000000000/1")
     in
     Hashtbl.set table ~key:"monero" ~data:monero ;
     Hashtbl.set table ~key:"decinero" ~data:decinero ;
@@ -5306,9 +5990,12 @@ module Crypto_SOL : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let sol = Discrete.Scale.make_scale symbol "sol" (make_q "1/1") in
+    let sol =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"sol" (make_q "1/1")
+    in
     let lamport =
-      Discrete.Scale.make_scale symbol "lamport" (make_q "100000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"lamport"
+        (make_q "100000000/1")
     in
     Hashtbl.set table ~key:"sol" ~data:sol ;
     Hashtbl.set table ~key:"lamport" ~data:lamport ;
@@ -5335,18 +6022,24 @@ module Crypto_DOT : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let dot = Discrete.Scale.make_scale symbol "dot" (make_q "1/1") in
+    let dot =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dot" (make_q "1/1")
+    in
     let million =
-      Discrete.Scale.make_scale symbol "million " (make_q "1/1000000")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"million "
+        (make_q "1/1000000")
     in
     let millidot =
-      Discrete.Scale.make_scale symbol "millidot " (make_q "1000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"millidot "
+        (make_q "1000/1")
     in
     let microdot =
-      Discrete.Scale.make_scale symbol "microdot " (make_q "100000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"microdot "
+        (make_q "100000/1")
     in
     let planck =
-      Discrete.Scale.make_scale symbol "million " (make_q "1000000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"million "
+        (make_q "1000000000/1")
     in
     Hashtbl.set table ~key:"dot" ~data:dot ;
     Hashtbl.set table ~key:"million" ~data:million ;
@@ -5376,9 +6069,12 @@ module Crypto_SHIB : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let shib = Discrete.Scale.make_scale symbol "dot" (make_q "1/1") in
+    let shib =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"dot" (make_q "1/1")
+    in
     let shiboshi =
-      Discrete.Scale.make_scale symbol "shiboshi " (make_q "100000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"shiboshi "
+        (make_q "100000000/1")
     in
     Hashtbl.set table ~key:"shib" ~data:shib ;
     Hashtbl.set table ~key:"shiboshi" ~data:shiboshi ;
@@ -5405,9 +6101,12 @@ module Crypto_XTZ : Custom = struct
 
   let units =
     let table = Hashtbl.create (module String) in
-    let tez = Discrete.Scale.make_scale symbol "tez" (make_q "1/1") in
+    let tez =
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"tez" (make_q "1/1")
+    in
     let mutez =
-      Discrete.Scale.make_scale symbol "mutez " (make_q "1000000/1")
+      Discrete.Scale.make_scale ~sym:symbol ~sub_unit:"mutez "
+        (make_q "1000000/1")
     in
     Hashtbl.set table ~key:"tez" ~data:tez ;
     Hashtbl.set table ~key:"mutez" ~data:mutez ;

--- a/lib/quotient.ml
+++ b/lib/quotient.ml
@@ -1,47 +1,58 @@
+open Sexplib.Std
+
 module Make (Qv : Qv_intf.S) = struct
   exception CurrencyTypeMismatch of string
 
-  type t = {symbol: string [@compare.ignore]; value: Qv.t}
-  [@@deriving compare]
+  type t = {symbol_: string; value_: Qv.t}
 
   type showable =
-    {symbol_: string [@key "symbol"]; value_: string [@key "value"]}
-  [@@deriving show, yojson]
+    { kind: string [@key "kind"]
+    ; symbol: string [@key "symbol"]
+    ; value: string [@key "value"] }
+  [@@deriving yojson, sexp]
 
   let check_sym t1 t2 =
-    if String.compare t1.symbol t2.symbol = 0 then true else false
+    if String.compare t1.symbol_ t2.symbol_ = 0 then true else false
 
-  let make_qv (symbol, qv) = {symbol; value= qv}
+  let make_qv (symbol_, value_) = {symbol_; value_}
 
-  let show_sym t = Printf.printf "%s" t.symbol
+  let show_sym t = Printf.printf "%s" t.symbol_
 
-  let show_val t = Printf.printf "%s" (Qv.S.to_str t.value)
+  let show_val t = Printf.printf "%s" (Qv.S.to_str t.value_)
 
-  let show_t t = Printf.printf "(%s %s)" t.symbol (Qv.S.to_str t.value)
+  let show_t t = Printf.printf "(%s %s)" t.symbol_ (Qv.S.to_str t.value_)
 
-  let neg t = {t with value= Qv.S.neg t.value}
+  let neg t = {t with value_= Qv.S.neg t.value_}
 
-  let abs t = {t with value= Qv.S.abs t.value}
+  let abs t = {t with value_= Qv.S.abs t.value_}
 
   let ( + ) t1 t2 =
-    if check_sym t1 t2 then {t1 with value= Qv.S.add t1.value t2.value}
+    if check_sym t1 t2 then {t1 with value_= Qv.S.add t1.value_ t2.value_}
     else
       raise
         (CurrencyTypeMismatch
            "cannot operate on two different currency types" )
 
   let ( - ) t1 t2 =
-    if check_sym t1 t2 then {t1 with value= Qv.S.sub t1.value t2.value}
+    if check_sym t1 t2 then {t1 with value_= Qv.S.sub t1.value_ t2.value_}
     else
       raise
         (CurrencyTypeMismatch
            "cannot operate on two different currency types" )
 
-  let ( * ) ~t ~value = {t with value= Qv.S.mul t.value value}
+  let ( * ) t qv = {t with value_= Qv.S.mul t.value_ qv}
 
-  let ( / ) t value = {t with value= Qv.S.div t.value value}
+  let ( / ) t qv = {t with value_= Qv.S.div t.value_ qv}
 
   let to_json x =
     Yojson.Safe.to_string
-    @@ showable_to_yojson {symbol_= x.symbol; value_= Qv.S.to_str x.value}
+    @@ showable_to_yojson
+         { kind= "quotient_value"
+         ; symbol= x.symbol_
+         ; value= Qv.S.to_str x.value_ }
+
+  let showable_of_t t =
+    {kind= "quotient_value"; symbol= t.symbol_; value= Qv.S.to_str t.value_}
+
+  let to_sexp t = sexp_of_showable @@ showable_of_t t
 end

--- a/lib/quotient.mli
+++ b/lib/quotient.mli
@@ -7,48 +7,46 @@ module Make (Qv : Qv_intf.S) : sig
 
   (** {1 Types} *)
   type t =
-    { symbol: string  (** Currency Symbol *)
-    ; value: Qv.t  (** Value in Rational *) }
-  [@@deriving compare]
-
-  (** showable for t *)
-  type showable =
-    {symbol_: string [@key "symbol"]; value_: string [@key "value"]}
-  [@@deriving show, yojson]
+    { symbol_: string  (** Currency Symbol *)
+    ; value_: Qv.t  (** Value in Rational *) }
+  (** Type of quotient *)
 
   (** {1 Construction} *)
   val make_qv : string * Qv.t -> t
-  (** Construct quotient value, e.g. make_qv "GBP" Utils.make_q("123456/100") *)
+  (** [make_qv name qv] makes t with a currenc symbol and quotient value, e.g. make_qv "GBP" make_q("123456/100") *)
 
   val show_sym : t -> unit
-  (** Print the currency symbol *)
+  (** [show_sym t] print t's currency symbol *)
 
   val show_val : t -> unit
-  (** Print the currency value *)
+  (** [show_val t] prints t's currency value *)
 
   val show_t : t -> unit
-  (** Print the quotient value *)
+  (** [show_t t] prints t's quotient value *)
 
   val neg : t -> t
-  (** Negate a quotient value *)
+  (** [neg t] negates t's quotient value *)
 
   val abs : t -> t
-  (** Return an absolute quotient value *)
+  (** [abs t] returns t's absolute quotient value *)
 
   val ( + ) : t -> t -> t
-  (** Add two quotient values with same symbol as required *)
+  (** [t1 + t2] adds two t *)
 
   val ( - ) : t -> t -> t
-  (** Substract two quotient values with same symbol as required *)
+  (** [t1 - t2] substracts two t *)
 
-  val ( * ) : t:t -> value:Qv.t -> t
-  (** Multiply a quotient value with a plain rational value.
-      Multiplying two quotient values does not make sense for currency ops. *)
+  val ( * ) : t -> Qv.t -> t
+  (** [t * qv] multiplies a t with a plain rational value.
+      Multiplying two quotient values does not make sense for currency ops *)
 
   val ( / ) : t -> Qv.t -> t
-  (** Divide a quotient value with a plain rational value.
-      Dividing two quotient values does not make sense for currency ops. *)
+  (** [t / qv] divides a t with a plain rational value.
+      Dividing two quotient values does not make sense for currency ops *)
 
   val to_json : t -> string
-  (** Convert t to json *)
+  (** [to_json t] converts t to json string *)
+
+  val to_sexp : t -> Base.Sexp.t
+  (** [to_sexp t] converts t to sexp *)
 end

--- a/lib/qv.ml
+++ b/lib/qv.ml
@@ -1,4 +1,4 @@
-type t = Q.t [@@deriving compare]
+type t = Q.t
 
 exception NonsensicalQuotientValue of string
 
@@ -7,23 +7,21 @@ exception DenominatorZero of string
 exception NonQuotientRep of string
 
 module S = struct
-  type showable = {value: string} [@@deriving show, yojson]
-
   let one () = Q.one
 
-  let neg x = Q.neg x
+  let neg t = Q.neg t
 
-  let abs x = Q.abs x
+  let abs t = Q.abs t
 
-  let signum x = Q.sign x
+  let signum t = Q.sign t
 
-  let add x y = Q.add x y
+  let add t1 t2 = Q.add t1 t2
 
-  let sub x y = Q.sub x y
+  let sub t1 t2 = Q.sub t1 t2
 
-  let mul x y = Q.mul x y
+  let mul t1 t2 = Q.mul t1 t2
 
-  let div x y = Q.div x y
+  let div t1 t2 = Q.div t1 t2
 
   let make str =
     let pat = Re2.create_exn "^-?[0-9]*/?-?[0-9]*?$" in
@@ -46,16 +44,13 @@ module S = struct
           (NonQuotientRep
              "only quotient representation allowed, e.g. 123/456" )
 
-  let num_of_q x = Q.num x
+  let num_of_q t = Q.num t
 
-  let den_of_q x = Q.den x
+  let den_of_q t = Q.den t
 
-  let to_str x =
-    if Z.compare (den_of_q x) Z.one = 0 then Q.to_string x ^ "/1"
-    else Q.to_string x
+  let to_str t =
+    if Z.compare (den_of_q t) Z.one = 0 then Q.to_string t ^ "/1"
+    else Q.to_string t
 
-  let to_float x = Q.to_float x
-
-  let to_json x =
-    Yojson.Safe.to_string @@ showable_to_yojson {value= to_str x}
+  let to_float t = Q.to_float t
 end

--- a/lib/qv_intf.ml
+++ b/lib/qv_intf.ml
@@ -1,14 +1,12 @@
-(** Rational Representation
+(* Rational Representation
 
-    Wrapper type for Zarith Q rational type {{:https://ocaml.org/p/zarith/latest/doc/Q/index.html} [Q]}
-    which serves as the underlying type for other currency types that are built based on rational values.
-
-    Apart from few helper conversion functions, this signature implement most of what is equivalent to
-    the Num typeclass sensibly. *)
+   Wrapper type for Zarith Q rational type
+   {{:https://ocaml.org/p/zarith/latest/doc/Q/index.html} [Q]} which serves
+   as the underlying type for other currency types that are built based on
+   rational values *)
 
 module type S = sig
-  (** {1 Types} *)
-  type t = private Q.t [@@deriving compare]
+  type t = private Q.t
 
   exception NonsensicalQuotientValue of string
 
@@ -17,53 +15,30 @@ module type S = sig
   exception NonQuotientRep of string
 
   module S : sig
-    (** showable for t *)
-    type showable = {value: string} [@@deriving show, yojson]
-
-    (** {1 Construction} *)
     val make : string -> t
-    (** Constructing Q by using a private type to only allow creation from string, e.g. [from_str "123/456"].
-        Reason behind is to disallow a range of functions that are unsuitable for currency operations. Nonsensical
-        and undefined rational numbers are checked/excluded. In the context of safe money we want to establish
-        a chain of proof that no lossy operations ever occurred. Helper function [make_q] is provided. *)
 
     val one : unit -> t
-    (** Return rational value of 1: "1/1" or "1" *)
 
     val neg : t -> t
-    (** Negate a Q value *)
 
     val abs : t -> t
-    (** Return an absolute Q value *)
 
     val signum : t -> int
-    (** Return the sign of Q value, -1, 0, or 1 when the argument is respectively negative, null, or positive. *)
 
     val add : t -> t -> t
-    (** Add two Q values *)
 
     val sub : t -> t -> t
-    (** Substract two Q values *)
 
     val mul : t -> t -> t
-    (** Multiply two Q values *)
 
     val div : t -> t -> t
-    (** Divide two Q values *)
 
     val num_of_q : t -> Z.t
-    (** Get the numerator of a Q value *)
 
     val den_of_q : t -> Z.t
-    (** Get the denominator of a Q value *)
 
     val to_str : t -> string
-    (** Convert a Q value to string *)
 
     val to_float : t -> float
-    (** Convert a Q value to float *)
-
-    val to_json : t -> string
-    (** Convert a Q value to json *)
   end
 end

--- a/lib/safemoney.ml
+++ b/lib/safemoney.ml
@@ -4,10 +4,10 @@ module Quotient = Types.Quotient
 module Predefined = Predefined
 module Ops = Ops
 
-let make_q v = Types.make_q v
+let make_q str = Types.make_q str
 
-let make_z v = Types.make_z v
+let make_z str = Types.make_z str
 
-let qv_to_str s = Types.q_to_str s
+let qv_to_str qv = Types.q_to_str qv
 
-let zv_to_str s = Types.z_to_str s
+let zv_to_str zv = Types.z_to_str zv

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -56,10 +56,10 @@ module type Custom = sig
   val make_dv : string -> Zv.t -> Discrete.t option
 end
 
-let make_q v = Qv.S.make v
+let make_q str = Qv.S.make str
 
-let make_z v = Zv.S.make v
+let make_z str = Zv.S.make str
 
-let q_to_str s = Qv.S.to_str s
+let q_to_str qv = Qv.S.to_str qv
 
-let z_to_str s = Zv.S.to_str s
+let z_to_str zv = Zv.S.to_str zv

--- a/lib/zv.ml
+++ b/lib/zv.ml
@@ -1,21 +1,21 @@
 type t = Z.t
 
 module S = struct
-  let neg x = Z.neg x
+  let neg t = Z.neg t
 
-  let abs x = Z.abs x
+  let abs t = Z.abs t
 
-  let signum x = Z.sign x
+  let signum t = Z.sign t
 
-  let add x y = Z.add x y
+  let add t1 t2 = Z.add t1 t2
 
-  let sub x y = Z.sub x y
+  let sub t1 t2 = Z.sub t1 t2
 
-  let mul x y = Z.mul x y
+  let mul t1 t2 = Z.mul t1 t2
 
   let make str = Z.of_string str
 
-  let to_str x = Z.to_string x
+  let to_str t = Z.to_string t
 
-  let to_float x = Z.to_float x
+  let to_float t = Z.to_float t
 end

--- a/lib/zv.ml
+++ b/lib/zv.ml
@@ -1,8 +1,6 @@
-type t = Z.t [@@deriving compare]
+type t = Z.t
 
 module S = struct
-  type showable = {value: string} [@@deriving show, yojson]
-
   let neg x = Z.neg x
 
   let abs x = Z.abs x
@@ -20,7 +18,4 @@ module S = struct
   let to_str x = Z.to_string x
 
   let to_float x = Z.to_float x
-
-  let to_json x =
-    Yojson.Safe.to_string @@ showable_to_yojson {value= to_str x}
 end

--- a/lib/zv_intf.ml
+++ b/lib/zv_intf.ml
@@ -1,50 +1,30 @@
-(** Integer Representation
+(* Integer Representation
 
-    Wrapper type for Zarith Z integer type {{:https://ocaml.org/p/zarith/latest/doc/Z/index.html} [Z]}
-    which serves as the underlying type for other currency types that are built based on integer values.
-
-    Apart from few helper conversion functions, this signature implement most of what is equivalent to
-    the Num typeclass sensibly. *)
+   Wrapper type for Zarith Z integer type
+   {{:https://ocaml.org/p/zarith/latest/doc/Z/index.html} [Z]} which serves
+   as the underlying type for other currency types that are built based on
+   integer values *)
 
 module type S = sig
-  (** {1 Types} *)
-  type t = private Z.t [@@deriving compare]
+  type t = private Z.t
 
   module S : sig
-    (** {1 Construction} *)
     val make : string -> t
-    (** Constructing Z by using a private type to only allow creation from string, e.g. [from_str "123"].
-        Reason behind is to disallow a range of functions that are unsuitable for currency operations.
-        Helper function [make_z] is provided. *)
-
-    (** showable for t *)
-    type showable = {value: string} [@@deriving show, yojson]
 
     val neg : t -> t
-    (** Negate a Z value *)
 
     val abs : t -> t
-    (** Return an absolute Z value *)
 
     val signum : t -> int
-    (** Return the sign of Z value, -1, 0, or 1 when the argument is respectively negative, null, or positive. *)
 
     val add : t -> t -> t
-    (** Add two Z values *)
 
     val sub : t -> t -> t
-    (** Substract two Z values *)
 
     val mul : t -> t -> t
-    (** Multiply two Z values *)
 
     val to_str : t -> string
-    (** Convert a Z value to string *)
 
     val to_float : t -> float
-    (** Convert a Z value to float *)
-
-    val to_json : t -> string
-    (** Convert a Z value to json *)
   end
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -4,11 +4,8 @@ let%expect_test "qv_ops" =
   let open Quotient in
   let qv1 = make_qv ("AUD", make_q "3/1") in
   let qv2 = make_qv ("AUD", make_q "2/1") in
-  let r =
-    abs
-      (neg (( * ) ~t:(qv1 + qv2 - qv2) ~value:(make_q "3/1") / make_q "3/1"))
-  in
-  qv_to_str r.value |> print_endline ;
+  let r = abs (neg ((qv1 + qv2 - qv2) * make_q "3/1" / make_q "3/1")) in
+  qv_to_str r.value_ |> print_endline ;
   [%expect {|3/1|}]
 
 (* qv_ops_diff_currency *)
@@ -17,11 +14,7 @@ let () =
   try
     let qv1 = make_qv ("AUD", make_q "3/1") in
     let qv2 = make_qv ("GBP", make_q "2/1") in
-    let _r =
-      abs
-        (neg
-           (( * ) ~t:(qv1 + qv2 - qv2) ~value:(make_q "3/1") / make_q "3/1") )
-    in
+    let _r = abs (neg ((qv1 + qv2 - qv2) * make_q "3/1" / make_q "3/1")) in
     Printf.printf "%s" ""
   with
   | CurrencyTypeMismatch _ -> ()
@@ -29,22 +22,28 @@ let () =
 
 let%expect_test "dv_ops_with_scale" =
   let open Discrete in
-  let scale = Scale.make_scale "AUD" "cent" (make_q "100/1") in
+  let scale =
+    Scale.make_scale ~sym:"AUD" ~sub_unit:"cent" (make_q "100/1")
+  in
   let dv1 = make_dv (scale, make_z "200") in
   let dv2 = make_dv (scale, make_z "100") in
-  let r = ( * ) ~t:(dv1 + dv2 - dv2) ~value:(make_z "10") in
-  zv_to_str r.value |> print_endline ;
+  let r = (dv1 + dv2 - dv2) * make_z "10" in
+  zv_to_str r.value_ |> print_endline ;
   [%expect {|2000|}]
 
 (* dv_ops_with_diff_scale *)
 let () =
   let open Discrete in
   try
-    let scale1 = Scale.make_scale "AUD" "cent" (make_q "100/1") in
-    let scale2 = Scale.make_scale "GBP" "penny" (make_q "100/1") in
+    let scale1 =
+      Scale.make_scale ~sym:"AUD" ~sub_unit:"cent" (make_q "100/1")
+    in
+    let scale2 =
+      Scale.make_scale ~sym:"GBP" ~sub_unit:"penny" (make_q "100/1")
+    in
     let dv1 = make_dv (scale1, make_z "200") in
     let dv2 = make_dv (scale2, make_z "100") in
-    let _r = ( * ) ~t:(dv1 + dv2 - dv2) ~value:(make_z "10") in
+    let _r = (dv1 + dv2 - dv2) * make_z "10" in
     Printf.printf "%s" ""
   with
   | ScaleTypeMismatch _ -> ()
@@ -54,7 +53,9 @@ let () =
 let () =
   let open Discrete in
   try
-    let _scale = Scale.make_scale "AUD" "cent" (make_q "-100/1") in
+    let _scale =
+      Scale.make_scale ~sym:"AUD" ~sub_unit:"cent" (make_q "-100/1")
+    in
     Printf.printf "%s" ""
   with
   | Scale.ValidScaleError _ -> ()
@@ -68,9 +69,9 @@ let%expect_test "xchg_ops" =
   in
   let aud_to_nzd = make_xchg ~src:"AUD" ~dst:"NZD" (make_q "4908/4503") in
   let gbp_to_nzd = gbp_to_aud **> aud_to_nzd in
-  gbp_to_nzd.src |> print_endline ;
-  gbp_to_nzd.dst |> print_endline ;
-  qv_to_str gbp_to_nzd.value |> print_endline ;
+  gbp_to_nzd.src_ |> print_endline ;
+  gbp_to_nzd.dst_ |> print_endline ;
+  qv_to_str gbp_to_nzd.value_ |> print_endline ;
   [%expect {|
     GBP
     NZD
@@ -98,14 +99,11 @@ let%expect_test "predefined" =
   let qv2 = ISO4217_AUD.make_qv (make_q "2/1") in
   let dv1 = Option.get (ISO4217_AUD.make_dv "cent" (make_z "200")) in
   let dv2 = Option.get (ISO4217_AUD.make_dv "cent" (make_z "100")) in
-  let rv =
-    abs
-      (neg (( * ) ~t:(qv1 + qv2 - qv2) ~value:(make_q "3/1") / make_q "3/1"))
-  in
+  let rv = abs (neg ((qv1 + qv2 - qv2) * make_q "3/1" / make_q "3/1")) in
   let open Discrete in
-  let dv = ( * ) ~t:(dv1 + dv2 - dv2) ~value:(make_z "10") in
-  qv_to_str rv.value |> print_endline ;
-  zv_to_str dv.value |> print_endline ;
+  let dv = (dv1 + dv2 - dv2) * make_z "10" in
+  qv_to_str rv.value_ |> print_endline ;
+  zv_to_str dv.value_ |> print_endline ;
   [%expect {|
     3/1
     2000|}]
@@ -120,7 +118,7 @@ let%expect_test "qv_to_decimal_up" =
     make_printing_conf ~sep:(sep_dot_comma ()) ~plus_sign:true
       ~num_of_digits:4 ~rounding:Up
   in
-  q_to_decimal ~printing_conf ~qv:(make_q "-1234567/7") |> print_endline ;
+  q_to_decimal ~printing_conf ~q:(make_q "-1234567/7") |> print_endline ;
   [%expect {|-176,366.0|}]
 
 let%expect_test "qv_to_decimal_truncate" =
@@ -129,7 +127,7 @@ let%expect_test "qv_to_decimal_truncate" =
     make_printing_conf ~sep:(sep_dot_comma ()) ~plus_sign:true
       ~num_of_digits:4 ~rounding:Truncate
   in
-  q_to_decimal ~printing_conf ~qv:(make_q "-1234567/7") |> print_endline ;
+  q_to_decimal ~printing_conf ~q:(make_q "-1234567/7") |> print_endline ;
   [%expect {|-176,366.7142|}]
 
 let%expect_test "decimal_to_qv_pos" =
@@ -174,8 +172,43 @@ let%expect_test "seal_quotient" =
 let%expect_test "unsafe_float_to_discrete" =
   let open Ops in
   let open Discrete.Scale in
-  let scale = make_scale "GBP" "Penny" (make_q "100/1") in
+  let scale = make_scale ~sym:"GBP" ~sub_unit:"Penny" (make_q "100/1") in
   let r = unsafe_float_to_discrete ~scale ~integer:123 in
   Discrete.to_json r |> print_endline ;
   [%expect
-    {|{"discrete_scale":"{\"symbol\":\"GBP\",\"unit\":\"Penny\",\"value\":\"100/1\"}","discrete_value":"{\"value\":\"123\"}"}|}]
+    {|{"kind":"discrete_value","symbol":"GBP","sub_unit":"Penny","scale_value":"100/1","discrete_value":"123"}|}]
+
+let%expect_test "sexp_of_scale" =
+  let open Discrete.Scale in
+  let scale = make_scale ~sym:"GBP" ~sub_unit:"Penny" (make_q "100/1") in
+  Base.Sexp.to_string @@ Discrete.Scale.to_sexp scale |> print_endline ;
+  [%expect {|((kind scale_value)(symbol GBP)(sub_unit Penny)(value 100/1))|}]
+
+let%expect_test "sexp_of_discrete" =
+  let open Ops in
+  let open Discrete.Scale in
+  let scale = make_scale ~sym:"GBP" ~sub_unit:"Penny" (make_q "100/1") in
+  let r = unsafe_float_to_discrete ~scale ~integer:123 in
+  Base.Sexp.to_string @@ Discrete.to_sexp r |> print_endline ;
+  [%expect
+    {|((kind discrete_value)(symbol GBP)(sub_unit Penny)(s_value 100/1)(value 123))|}]
+
+let%expect_test "sexp_of_exchange" =
+  let open Exchange in
+  let gbp_to_aud =
+    xchg_recip
+      (xchg_recip (make_xchg ~src:"GBP" ~dst:"AUD" (make_q "8872/4503")))
+  in
+  let aud_to_nzd = make_xchg ~src:"AUD" ~dst:"NZD" (make_q "4908/4503") in
+  let gbp_to_nzd = gbp_to_aud **> aud_to_nzd in
+  Base.Sexp.to_string @@ Exchange.to_sexp gbp_to_nzd |> print_endline ;
+  [%expect
+    {|((kind exchange_rate)(src GBP)(dst NZD)(value 14514592/6759003))|}]
+
+let%expect_test "sexp_of_quotient" =
+  let open Quotient in
+  let qv1 = make_qv ("AUD", make_q "3/1") in
+  let qv2 = make_qv ("AUD", make_q "2/1") in
+  let r = abs (neg ((qv1 + qv2 - qv2) * make_q "3/1" / make_q "3/1")) in
+  Base.Sexp.to_string @@ Quotient.to_sexp r |> print_endline ;
+  [%expect {|((kind quotient_value)(symbol AUD)(value 3/1))|}]


### PR DESCRIPTION
## Motivation

Addressing issues related to issue:
[https://github.com/gborough/safemoney/issues/8#issue-2905540566](url)

## Solution
Derive sexp using ppx_sexp_conv and use sexp to string conversion to represent Q and Z values